### PR TITLE
fix: reset session state and FIT records on new route import (fixes #41)

### DIFF
--- a/app.go
+++ b/app.go
@@ -393,6 +393,11 @@ func (a *App) startSession() string {
 	a.sessionTicks = 0
 	a.workoutIntensity = 1.0
 
+	// Clear the .FIT file array from memory to avoid altering routes.
+	if a.fitService != nil {
+		a.fitService.StartSession(a.sessionStart)
+	}
+
 	a.isRecording = true
 	a.isPaused = false
 
@@ -525,6 +530,7 @@ func (a *App) FinishSession() string {
 	// 6. Final cleanup
 	a.isRecording = false
 	a.isPaused = false
+	a.currentDist = 0
 
 	runtime.EventsEmit(a.ctx, "status_change", "IDLE")
 	return "Finished"
@@ -540,6 +546,8 @@ func (a *App) DiscardSession() string {
 		a.isRecording = false
 		a.isPaused = false
 	}
+
+	a.currentDist = 0
 
 	a.UnloadWorkout()
 

--- a/frontend/src/modules/MapController.js
+++ b/frontend/src/modules/MapController.js
@@ -283,8 +283,17 @@ export class MapController {
         }
     }
 
+    resetState() {
+        this.prevLngLat = null;
+        this.lastXPDist = 0;
+        this.followCyclist = true;
+    }
+
     renderRoute(geojson) {
         this.routeGeoJSON = geojson;
+
+        this.resetState();
+        
         if (this.map.loaded()) {
             this.addRouteLayer();
         }


### PR DESCRIPTION
### Bug Fix
This PR resolves the state leak issue where importing a new route would retain the data from the previous session, resulting in merged `.FIT` activities.

### Solution
- Added `a.fitService.StartSession()` inside `startSession()` in `app.go` to ensure a fresh FIT file is created.
- Forced `currentDist = 0` cleanup on `FinishSession` and `DiscardSession`.
- Implemented a `resetState()` method in `MapController.js` to clear previous `prevLngLat` and tracking variables before rendering a new route.

Closes #41