### PR TITLE
feat: implement route distance preview on HUD (closes #31)

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -169,6 +169,8 @@ document.getElementById('btnImport').addEventListener('click', async () => {
             if (routePoints.length > 1) {
                 window.totalRouteDistance = routePoints[routePoints.length - 1].distance;
 
+                ui.showRoutePreview(window.totalRouteDistance);
+
                 // Build GeoJSON from route segments
                 const features = [];
                 for (let i = 0; i < routePoints.length - 1; i++) {

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -177,6 +177,47 @@ export class UIManager {
         this.els.filename.innerText = "| " + name;
     }
 
+    // =================
+    // ROUTE PREVIEW
+    // =================
+
+    /**
+     * Display route statistics before the ride starts.
+     * @param {number} totalDistance - Total route distance in meters
+     * @param {number} totalElevation - Total elevation gain in meters (optional)
+     */
+    showRoutePreview(totalDistance, totalElevation = 0) {
+        // Reset telemetry values to zero/dash
+        this.els.watts.innerHTML = `0<span class="data-unit">w</span>`;
+        this.els.rpm.innerHTML = `0<span class="data-unit">rpm</span>`;
+        this.els.hr.innerHTML = `--<span class="data-unit">❤</span>`;
+        this.els.grade.innerHTML = `0.0<span class="data-unit">%</span>`;
+        this.els.speed.innerHTML = `0.0<span class="data-unit">km/h</span>`; // Or miles based on preference
+        this.els.wkg.innerHTML = `0.0<span class="data-unit">w/kg</span>`;
+
+        // Reset Timer
+        this.els.time.innerText = `00:00:00`;
+
+        // Set the Total Distance
+        const distObj = this.formatDist(totalDistance);
+        this.els.dist.innerHTML = `0.0<span class="data-unit">${distObj.unit}</span>`; // Start at 0
+
+        // Set the Remaining Distance to the Total Distance
+        const remObj = this.formatDist(totalDistance);
+        this.els.distRem.innerHTML = `${remObj.val}<span class="data-unit">${remObj.unit}</span>`;
+
+        // If you have a specific UI element for Elevation, update it here.
+        // For example, if you added: this.els.elevation = document.getElementById('total-elevation');
+        // if (this.els.elevation) {
+        //     this.els.elevation.innerHTML = `${totalElevation.toFixed(0)}<span class="data-unit">m</span>`;
+        // }
+
+        // Reset Cursor
+        if (this.els.cursor) {
+            this.els.cursor.style.left = '0%';
+        }
+    }
+
     // ===========
     // TIMER LOGIC
     // ===========


### PR DESCRIPTION
###  Feature
This PR implements the route preview functionality on the left HUD. When a user imports a GPX file, the UI now immediately updates to show the total route distance and resets the timer and telemetry data, giving the user context before they click "Start Ride".

###  Changes Made
- Added `showRoutePreview(totalDistance)` method in `UIManager.js` to reset stats and display the remaining distance.
- Updated the GPX import logic in `main.js` to call the preview method immediately after calculating the total route distance.

Closes #31