### PR TITLE
ui: add accumulated elevation gain to left telemetry HUD (closes #39)

### DIFF
--- a/app.go
+++ b/app.go
@@ -66,13 +66,15 @@ type App struct {
 	cancelSim     context.CancelFunc
 
 	// Session metadata
-	currentRouteName string    // Selected GPX route name
-	sessionStart     time.Time // Session start time (for duration calculation)
-	sessionActiveTime float64
-	sessionPowerSum  uint64    // Sum of power samples (for average power)
-	sessionTicks     int       // Number of power samples
-	sessionPowerData []int
-	simPower         int16
+	currentRouteName     string    // Selected GPX route name
+	sessionStart         time.Time // Session start time (for duration calculation)
+	sessionActiveTime    float64
+	sessionPowerSum      uint64 // Sum of power samples (for average power)
+	sessionTicks         int    // Number of power samples
+	sessionPowerData     []int
+	simPower             int16
+	sessionElevationGain float64
+	lastAltitude         float64
 }
 
 type ExportPoint struct {
@@ -196,13 +198,12 @@ func (a *App) UpdateUserProfile(u domain.UserProfile) string {
 
 // GetActivities returns recent recorded activities.
 func (a *App) GetActivities() []domain.Activity {
-    // Passa -1 ou 0 para indicar "sem limite"
-    activities, err := a.storageService.GetRecentActivities(-1) 
+	activities, err := a.storageService.GetRecentActivities(-1)
 
-    if err != nil {
-        return []domain.Activity{}
-    }
-    return activities
+	if err != nil {
+		return []domain.Activity{}
+	}
+	return activities
 }
 
 // GetTotalStats returns aggregated statistics.
@@ -394,6 +395,8 @@ func (a *App) startSession() string {
 	a.sessionPowerSum = 0
 	a.sessionTicks = 0
 	a.workoutIntensity = 1.0
+	a.sessionElevationGain = 0.0
+	a.lastAltitude = -9999.0
 
 	// Clear the .FIT file array from memory to avoid altering routes.
 	if a.fitService != nil {
@@ -753,6 +756,11 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 			speedMs := a.physicsEngine.CalculateSpeed(float64(currentPower), routePoint.Grade)
 			a.currentDist += speedMs * dt
 
+			if a.lastAltitude != -9999.0 && routePoint.Elevation > a.lastAltitude {
+				a.sessionElevationGain += (routePoint.Elevation - a.lastAltitude)
+			}
+			a.lastAltitude = routePoint.Elevation
+
 			// End of Route Check (only if a route is loaded)
 			if totalRouteDistance > 0 && a.currentDist >= totalRouteDistance {
 				a.currentDist = totalRouteDistance
@@ -770,6 +778,7 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 				Timestamp: now, Power: currentPower, Cadence: currentCadence, HeartRate: currentHR,
 				Speed: speedMs * 3.6, TotalDistance: a.currentDist, CurrentGrade: routePoint.Grade,
 				Latitude: routePoint.Latitude, Longitude: routePoint.Longitude, Altitude: routePoint.Elevation,
+				ElevationGain: a.sessionElevationGain,
 			}
 			a.fitService.AddRecord(fullTelemetry)
 			runtime.EventsEmit(a.ctx, "telemetry_update", fullTelemetry)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -265,6 +265,11 @@
                 <div class="data-value val-grade" id="grade">0.0<span class="data-unit">%</span></div>
             </div>
 
+            <div class="data-card">
+                <span class="data-value" id="elevation">0<span class="data-unit">m</span></span>
+                <span class="data-label">Elevation</span>
+            </div>
+
             <div class="data-card mt-auto"><span class="data-label">Distance</span>
                 <div class="data-value" id="dist">0.0<span class="data-unit">km</span></div>
             </div>

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -36,6 +36,7 @@ export class UIManager {
             hr: document.getElementById('hr'),
             rpm: document.getElementById('rpm'),
             grade: document.getElementById('grade'),
+            elevation: document.getElementById('elevation'),
             dist: document.getElementById('dist'),
             speed: document.getElementById('speed'),
             time: document.getElementById('time'),
@@ -153,6 +154,16 @@ export class UIManager {
         const distObj = this.formatDist(data.total_dist);
         this.els.dist.innerHTML = `${distObj.val}<span class="data-unit">${distObj.unit}</span>`;
 
+        // Elevation Gain (unit-aware and NaN-safe)
+        if (this.els.elevation) {
+            const accumulatedGain = data.elevation_gain || 0;
+            const isImperial = this.units === 'imperial';
+            const eleVal = isImperial ? (accumulatedGain * 3.28084) : accumulatedGain;
+            const eleUnit = isImperial ? 'ft' : 'm';
+
+            this.els.elevation.innerHTML = `${Math.round(eleVal)}<span class="data-unit">${eleUnit}</span>`;
+        }
+
         // Watts per kilogram
         const totalWeight = this.riderWeight;
         const wkgVal = (data.power / totalWeight).toFixed(2);
@@ -192,6 +203,12 @@ export class UIManager {
         this.els.rpm.innerHTML = `0<span class="data-unit">rpm</span>`;
         this.els.hr.innerHTML = `--<span class="data-unit">❤</span>`;
         this.els.grade.innerHTML = `0.0<span class="data-unit">%</span>`;
+
+        if (this.els.elevation) {
+            const eleUnit = this.units === 'imperial' ? 'ft' : 'm';
+            this.els.elevation.innerHTML = `0<span class="data-unit">${eleUnit}</span>`;
+        }
+
         this.els.speed.innerHTML = `0.0<span class="data-unit">km/h</span>`; // Or miles based on preference
         this.els.wkg.innerHTML = `0.0<span class="data-unit">w/kg</span>`;
 

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -43,7 +43,7 @@ type Telemetry struct {
 	Latitude      float64   `json:"lat"`        // Current latitude
 	Longitude     float64   `json:"lon"`        // Current longitude
 	Altitude      float64   `json:"alt"`        //Current altitude in meters
-
+	ElevationGain float64   `json:"elevation_gain"` //Cumulative elevation gain
 }
 
 // AppState represents the global state of the application.


### PR DESCRIPTION
### UI/UX Improvement
This PR enhances the telemetry HUD by adding a real-time **Elevation Gain** tracker. Instead of just showing the raw current altitude, the system now calculates the accumulated ascent during the ride.

### Technical Changes
- **Backend (`models.go` & `app.go`):** - Added `ElevationGain` to the `Telemetry` struct.
  - Implemented logic in the physics `gameLoop` to track the previous altitude and accumulate positive elevation changes into `sessionElevationGain`.
  - Added state resets in `startSession()` to prevent cross-workout data leaking.
- **Frontend (`index.html` & `UIManager.js`):**
  - Added the `ELEVATION` data card to the left sidebar.
  - Implemented unit-awareness in `updateTelemetry()` to automatically convert the accumulated meters to feet (`ft`) if the user's preference is set to Imperial.
  - Added safe fallbacks to prevent `NaN` errors if data is missing.

Closes #39