### PR TITLE
feat: Add Virtual Trainer Mode and dynamic hardware connection toggles

### DIFF
--- a/app.go
+++ b/app.go
@@ -95,7 +95,7 @@ func NewApp() *App {
 		gpxService: gpx.NewService(),
 		fitService: fit.NewService(),
 		// Initialize physics engine using stored user data
-		physicsEngine: sim.NewEngine(profile.Weight, profile.BikeWeight),
+		physicsEngine:  sim.NewEngine(profile.Weight, profile.BikeWeight),
 		trainerService: ble.NewRealService(),
 		//trainerService: ble.NewMockService(),
 		workoutService: workout.NewService(),
@@ -322,11 +322,13 @@ func (a *App) ToggleAlwaysOnTop(on bool) {
 	runtime.WindowSetAlwaysOnTop(a.ctx, on)
 }
 
-// ConnectTrainer connects to the smart trainer via BLE.
+// ConnectTrainer connects to the smart trainer via real BLE hardware.
 func (a *App) ConnectTrainer() (string, error) {
-	if a.isTrainerConnected {
-		return "Trainer Already Connected", nil
+	if a.isTrainerConnected && a.trainerService != nil {
+		a.trainerService.Disconnect() 
 	}
+
+	a.trainerService = ble.NewRealService()
 
 	statusCallback := func(stage string, data string) {
 		runtime.EventsEmit(a.ctx, "ble_connection_status", map[string]string{"stage": stage, "msg": data})
@@ -338,6 +340,39 @@ func (a *App) ConnectTrainer() (string, error) {
 
 	a.isTrainerConnected = true
 	return "Trainer Connected", nil
+}
+
+// ConnectVirtualTrainer overrides the real BLE service with a mock generator
+// to allow software testing and presentation without physical hardware.
+func (a *App) ConnectVirtualTrainer() (string, error) {
+	if a.isTrainerConnected {
+		// If something is already connected (real or another mock), disconnect it first.
+		a.trainerService.Disconnect()
+	}
+
+	// // Injects the Mock (Virtual Trainer) dependency.
+	a.trainerService = ble.NewMockService()
+
+	statusCallback := func(stage string, data string) {
+		runtime.EventsEmit(a.ctx, "ble_connection_status", map[string]string{"stage": stage, "msg": data})
+	}
+
+	if err := a.trainerService.ConnectTrainer(statusCallback); err != nil {
+		return "Simulator Error", err
+	}
+
+	a.isTrainerConnected = true
+	return "Simulator Active", nil
+}
+
+// DisconnectTrainer explicitly disconnects the active trainer (real or virtual)
+// allowing the user to switch between simulation and real hardware.
+func (a *App) DisconnectTrainer() string {
+	if a.isTrainerConnected && a.trainerService != nil {
+		a.trainerService.Disconnect()
+		a.isTrainerConnected = false
+	}
+	return "Disconnected"
 }
 
 // ConnectHeartRate connects to a heart rate monitor.
@@ -356,6 +391,16 @@ func (a *App) ConnectHeartRate() (string, error) {
 
 	a.isHRConnected = true
 	return "HR Monitor Connected", nil
+}
+
+// DisconnectHeartRate explicitly disconnects the HR monitor at the hardware level.
+func (a *App) DisconnectHeartRate() string {
+	if a.isHRConnected && a.trainerService != nil {
+		// Agora sim, manda a antena Bluetooth cortar a conexão!
+		a.trainerService.DisconnectHR() 
+		a.isHRConnected = false
+	}
+	return "Disconnected"
 }
 
 // =================

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,7 +97,10 @@
                                 <span>Trainer</span>
                                 <div>
                                     <span id="statusTrainer" class="status-indicator">Disconnected</span>
-                                    <button id="btnConnTrainer" class="btn-icon-small" title="Connect">🔗</button>
+                                    <button id="btnConnVirtual" class="btn-icon-small" title="Use Simulator"
+                                        style="margin-right: 5px;">💻</button>
+                                    <button id="btnConnTrainer" class="btn-icon-small"
+                                        title="Connect Real Hardware">🔗</button>
                                 </div>
                             </div>
                             <div class="device-row compact">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -101,23 +101,86 @@ document.getElementById('btnOpenSettings').addEventListener('click', () => {
 // DEVICE CONNECTIONS
 // ==================
 
+// REAL TRAINER CONNECTION
 document.getElementById('btnConnTrainer').addEventListener('click', async () => {
-    const btn = document.getElementById('btnConnTrainer');
+    const btnVirtual = document.getElementById('btnConnVirtual');
+    const btnReal = document.getElementById('btnConnTrainer');
     const status = document.getElementById('statusTrainer');
 
-    btn.innerText = "Scanning...";
-    btn.disabled = true;
+    // If already connected (Real), clicking will disconnect
+    if (status.innerText === "Trainer Connected") {
+        await window.go.main.App.DisconnectTrainer();
+        status.innerText = "Disconnected";
+        status.style.color = "";  // Remove color (revert to CSS default)
+        btnReal.innerText = "🔗"; // Restore original icon
+        btnVirtual.disabled = false; // Re-enable Virtual button
+        return;
+    }
+
+    btnReal.innerText = "⏳";
+    btnReal.disabled = true;
+    btnVirtual.disabled = true; // Disable Virtual while attempting Real connection
 
     try {
         const result = await window.go.main.App.ConnectTrainer();
-        status.innerText = result; // Ex: "Trainer Connected"
+        status.innerText = result; // Example: "Trainer Connected"
         status.style.color = "var(--argus-safe)";
-        btn.innerText = "Connected";
+        btnReal.innerText = "❌";  // Change icon to suggest "Disconnect"
+        btnReal.disabled = false;
     } catch (err) {
         status.innerText = "Error: " + err;
         status.style.color = "var(--argus-alert)";
-        btn.innerText = "Retry";
-        btn.disabled = false;
+        btnReal.innerText = "Retry";
+        btnReal.disabled = false;
+        btnVirtual.disabled = false;
+    }
+});
+
+// SIMULATOR (VIRTUAL) CONNECTION
+document.getElementById('btnConnVirtual').addEventListener('click', async () => {
+    const btnVirtual = document.getElementById('btnConnVirtual');
+    const btnReal = document.getElementById('btnConnTrainer');
+    const status = document.getElementById('statusTrainer');
+
+    // If already connected (Virtual), clicking will disconnect
+    if (status.innerText === "Simulator Active") {
+        await window.go.main.App.DisconnectTrainer();
+        status.innerText = "Disconnected";
+        status.style.color = "";  // Remove color
+        btnVirtual.innerText = "💻"; // Restore original icon
+        btnReal.disabled = false; // Re-enable Real button
+        return;
+    }
+
+    btnVirtual.innerText = "⏳";
+    btnVirtual.disabled = true;
+    btnReal.disabled = true; // Change icon to suggest "Disconnect"
+
+    try {
+        const result = await window.go.main.App.ConnectVirtualTrainer();
+        status.innerText = result; // Example: "Simulator Active"
+        status.style.color = "#00ADD8";
+        btnVirtual.innerText = "❌"; // Change icon to suggest "Disconnect"
+        btnVirtual.disabled = false;
+
+        // Visual Feedback
+        const toast = document.getElementById('toast-notification');
+        if (toast) {
+            toast.innerText = "💻 Virtual Trainer Mode Activated!";
+            toast.classList.remove('hidden');
+            toast.style.display = 'block';
+            setTimeout(() => {
+                toast.classList.add('hidden');
+                toast.style.display = 'none';
+            }, 3000);
+        }
+
+    } catch (err) {
+        status.innerText = "Error: " + err;
+        status.style.color = "var(--argus-alert)";
+        btnVirtual.innerText = "💻";
+        btnVirtual.disabled = false;
+        btnReal.disabled = false;
     }
 });
 
@@ -125,16 +188,27 @@ document.getElementById('btnConnHR').addEventListener('click', async () => {
     const btn = document.getElementById('btnConnHR');
     const status = document.getElementById('statusHR');
 
-    btn.innerText = "Scanning...";
+    // If already connected, clicking will disconnect
+    if (status.innerText === "HR Monitor Connected" || status.innerText === "Connected") {
+        await window.go.main.App.DisconnectHeartRate();
+        status.innerText = "Disconnected";
+        status.style.color = ""; // Remove color (revert to CSS default)
+        btn.innerText = "🔗";   // Restore original icon
+        return;
+    }
+
+    btn.innerText = "⏳";
     btn.disabled = true;
 
     try {
         const result = await window.go.main.App.ConnectHeartRate();
-        status.innerText = result;
+        status.innerText = result; // Example: "HR Monitor Connected"
         status.style.color = "var(--argus-safe)";
-        btn.innerText = "Connected";
+        btn.innerText = "❌"; // Change icon to suggest "Disconnect"
+        btn.disabled = false;
     } catch (err) {
         status.innerText = "Error";
+        status.style.color = "var(--argus-alert)";
         btn.innerText = "Retry";
         btn.disabled = false;
     }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -12,9 +12,15 @@ export function ConnectHeartRate():Promise<string>;
 
 export function ConnectTrainer():Promise<string>;
 
+export function ConnectVirtualTrainer():Promise<string>;
+
 export function DiscardSession():Promise<string>;
 
 export function DisconnectDevice():Promise<string>;
+
+export function DisconnectHeartRate():Promise<string>;
+
+export function DisconnectTrainer():Promise<string>;
 
 export function FinishSession():Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -18,12 +18,24 @@ export function ConnectTrainer() {
   return window['go']['main']['App']['ConnectTrainer']();
 }
 
+export function ConnectVirtualTrainer() {
+  return window['go']['main']['App']['ConnectVirtualTrainer']();
+}
+
 export function DiscardSession() {
   return window['go']['main']['App']['DiscardSession']();
 }
 
 export function DisconnectDevice() {
   return window['go']['main']['App']['DisconnectDevice']();
+}
+
+export function DisconnectHeartRate() {
+  return window['go']['main']['App']['DisconnectHeartRate']();
+}
+
+export function DisconnectTrainer() {
+  return window['go']['main']['App']['DisconnectTrainer']();
 }
 
 export function FinishSession() {

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -27,6 +27,9 @@ type TrainerService interface {
 	// ConnectHR connects ONLY to the Heart Rate Monitor
 	ConnectHR(onStatus func(string, string)) error
 
+	// Disconnect only the HR at the hardware level
+	DisconnectHR()
+
 	// SubscribeStats starts reading data from connected devices
 	SubscribeStats(dataChan chan Telemetry) error
 

--- a/internal/service/ble/mock.go
+++ b/internal/service/ble/mock.go
@@ -98,3 +98,7 @@ func (m *MockService) SubscribeStats(ch chan domain.Telemetry) error {
 	}()
 	return nil
 }
+
+func (m *MockService) DisconnectHR() {
+	m.currentHR = 0
+}

--- a/internal/service/ble/real.go
+++ b/internal/service/ble/real.go
@@ -386,3 +386,12 @@ func parseHR(buf []byte) uint8 {
 	if buf[0]&0x01 == 0 { return buf[1] }
 	return buf[1]
 }
+
+// DisconnectHR explicitly drops the Bluetooth connection with the HR monitor
+func (s *RealService) DisconnectHR() {
+	if s.hrDevice != nil {
+		s.hrDevice.Disconnect()
+		s.hrDevice = nil
+		fmt.Println("[BLE] HR Device Disconnected")
+	}
+}


### PR DESCRIPTION
### Feature Description (Closes #52)
This PR introduces a built-in "Virtual Trainer" mode directly accessible from the UI, significantly improving Developer Experience (DX) and enabling hardware-less demonstrations

### Key Changes & Architecture Updates:
- **Simulator Injection:** Added `ConnectVirtualTrainer()` to the Go backend, allowing dynamic injection of `ble.NewMockService()` at runtime without needing to recompile the code.
- **Independent Toggles:** Redesigned the Connections UI in `index.html` and `main.js`. Users can now explicitly Connect/Disconnect the Smart Trainer and Heart Rate monitor independently using a toggle system (🔗 -> ❌).
- **Seamless Switching:** Fixed a state mutation bug in `app.go`. The system now correctly reinstantiates `ble.NewRealService()` when switching back from the Virtual Simulator to physical FTMS hardware within the same session.
- **Deep Disconnects:** Updated `TrainerService` interface to support hardware-level targeted disconnections (`DisconnectHR()`). This ensures the OS Bluetooth stack explicitly drops the HR sensor connection when requested, preventing battery drain and background ghost-reads.
- **Visual Feedback:** Added cyan text highlights and a dynamic Toast Notification to clearly indicate when the software is running in mock mode.