### PR TITLE
fix(ui): trigger finish modal on manual save (closes #51)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -353,7 +353,7 @@
         <div class="modal-content finish-content">
             <div class="finish-icon">🏆</div>
             <h2>Workout Completed!</h2>
-            <p>Congratulations, you conquered this route.</p>
+            <p>Route session completed.</p>
 
             <div class="finish-status">
                 ✅ Activity Saved Successfully

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -298,6 +298,19 @@ document.getElementById('btnLoadWorkout').addEventListener('click', async () => 
 // RECORDING CONTROLS
 // ==================
 
+// Isolated function to centralize the session finish logic
+async function finishWorkout() {
+    isFinishTriggered = true;
+    isRecording = false;
+    try {
+        await window.go.main.App.FinishSession();
+        ui.showFinishModal();
+    } catch (e) {
+        console.error("Error saving workout:", e);
+        alert("Error when saving: " + e);
+    }
+}
+
 document.getElementById('btnAction').addEventListener('click', async () => {
     try {
         if (!isRecording) {
@@ -321,9 +334,7 @@ document.getElementById('btnResume').addEventListener('click', async () => {
 });
 
 document.getElementById('btnFinishSave').addEventListener('click', async () => {
-    await window.go.main.App.FinishSession();
-    ui.setRecordingState('IDLE');
-    isRecording = false;
+    await finishWorkout();
 });
 
 document.getElementById('btnDiscard').addEventListener('click', async () => {
@@ -405,16 +416,4 @@ if (window.runtime) {
             }
         }
     });
-
-    async function finishWorkout() {
-        isFinishTriggered = true;
-        isRecording = false;
-        try {
-            await window.go.main.App.FinishSession();
-            ui.showFinishModal();
-        } catch (e) {
-            console.error("Error saving workout:", e);
-            alert("Error when saving: " + e);
-        }
-    }
 }


### PR DESCRIPTION
### Description (Closes #51)
This PR standardizes the user experience when concluding an activity. 

Previously, manually stopping a ride and selecting "Finish & Save" would abruptly close the session without providing visual feedback. The finish modal and animations were only triggered when the user reached the end of the loaded route automatically.

### Changes Made
* Refactored `frontend/src/main.js` to hoist the `finishWorkout()` function to a globally accessible scope.
* Updated the `btnFinishSave` event listener to call `finishWorkout()`, ensuring the exact same sequence (saving to backend + triggering `ui.showFinishModal()`) executes regardless of how the ride ended.
* Cleaned up redundant logic.

### How to Test
1. Start any Free Ride or Route.
2. Click "STOP RIDE" to pause the session.
3. Click "Finish & Save" in the confirmation modal.
4. Verify that the "Workout Completed" modal with the trophy icon appears, instead of silently returning to the IDLE state.