### PR TITLE
fix: Prevent premature session finish (missing meters)

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -411,7 +411,7 @@ if (window.runtime) {
         mapCtrl.updateCyclistPosition(data.lat, data.lon, data.speed, data);
 
         if (isRecording && totalRouteDistance > 0 && !isFinishTriggered) {
-            if (data.total_dist >= totalRouteDistance - 20) {
+            if (data.total_dist >= totalRouteDistance) {
                 finishWorkout();
             }
         }


### PR DESCRIPTION
### Description (Closes #26)
This PR addresses the "missing meters" bug where a simulated ride would automatically trigger the finish event slightly before the actual end of the route. 

### Cause & Changes Made
* **Cause:** There was a hardcoded `- 20` meter tolerance in the distance verification logic (`data.total_dist >= totalRouteDistance - 20`) left over from early testing/GPS tolerance assumptions.
* **Fix:** Removed the `20` meter offset in `frontend/src/main.js`. The `telemetry_update` event now strictly requires `data.total_dist >= totalRouteDistance` to trigger `finishWorkout()`.

### How to Test
1. Load any GPX route or create a short one in the Route Editor.
2. Start the ride in Virtual/Simulator mode.
3. Observe the "Remaining Distance" in the HUD.
4. Verify that the Finish Modal is only triggered when the remaining distance hits exactly `0.0 km`.