### PR TITLE
fix: Allow closing the workout panel and returning to Free Ride

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -42,13 +42,21 @@ window.totalRouteDistance = 0;
 let isRecording = false;
 let isFinishTriggered = false;
 
-window.closeWorkout = () => {
-    if (isRecording) {
-        if (confirm("Stop current workout?")) {
-            window.go.main.App.DiscardSession();
+window.closeWorkout = async () => {
+    if (confirm("Stop the structured workout and return to Free Ride?")) {
+        
+        if (typeof workoutCtrl !== 'undefined') {
+            workoutCtrl.hide();
         }
-    } else {
-        workoutCtrl.close();
+
+        // Notify the backend to stop ERG Mode and return to normal simulation (SIM)
+        if (window.go && window.go.main && window.go.main.App) {
+            try {
+                await window.go.main.App.SetTrainerMode('SIM');
+            } catch (e) {
+                console.error("Error returning to SIM mode:", e);
+            }
+        }
     }
 };
 


### PR DESCRIPTION
### Description (Closes #50)
This PR fixes a critical UX issue where the structured workout panel could not be dismissed. It also fixes a dangerous logic flaw that would accidentally discard the user's entire ride data when they only intended to stop the current workout interval.

### Cause & Changes Made
* **TypeError Fixed:** Changed the incorrect `workoutCtrl.close()` call to the correct `workoutCtrl.hide()` method in `main.js`, resolving the silent JavaScript crash that kept the panel stuck.
* **Safe Exit Logic:** Removed the `DiscardSession()` call from the close button event. 
* **Mode Switching:** The close button now gracefully hides the UI and sends a command to the backend to revert the trainer control to `SIM` (Free Ride) mode, allowing the user to keep pedaling and save their activity normally.

### How to Test
1. Load a `.ZWO` or structured workout to open the right-side panel.
2. Start the ride (Recording state).
3. Click the `✕` (Close) button on the workout panel header.
4. Accept the confirmation prompt.
5. Verify that the panel disappears, the HUD updates, and the session continues running normally in Free Ride mode without discarding the current distance.