### PR TITLE
fix(bug): HR monitor shows 0 BPM if connected before the Smart Trainer

### DIFF
--- a/app.go
+++ b/app.go
@@ -325,10 +325,12 @@ func (a *App) ToggleAlwaysOnTop(on bool) {
 // ConnectTrainer connects to the smart trainer via real BLE hardware.
 func (a *App) ConnectTrainer() (string, error) {
 	if a.isTrainerConnected && a.trainerService != nil {
-		a.trainerService.Disconnect() 
+		a.trainerService.Disconnect()
 	}
 
-	a.trainerService = ble.NewRealService()
+	if _, isReal := a.trainerService.(*ble.RealService); !isReal {
+		a.trainerService = ble.NewRealService()
+	}
 
 	statusCallback := func(stage string, data string) {
 		runtime.EventsEmit(a.ctx, "ble_connection_status", map[string]string{"stage": stage, "msg": data})


### PR DESCRIPTION
### Description
Resolves a bug where the Heart Rate monitor data would drop to `0` if the user connected the HR sensor before connecting the Smart Trainer. 

### Cause & Changes Made
* **Cause:** The `ConnectTrainer()` function in `app.go` was unconditionally overwriting the `a.trainerService` variable with a brand new `ble.NewRealService()` instance. If an HR monitor was already connected, its pointer (`hrDevice`) was wiped out of application state.
* **Fix:** Implemented a type assertion check (`a.trainerService.(*ble.RealService)`). The system now reuses the existing `RealService` instance if it's already active, preserving the active HR Bluetooth link while successfully binding the Trainer device.

### How to Test
1. Open Argus Cyclist and go to the Devices modal.
2. Click **Connect Heart Rate** FIRST. Wait for the success status.
3. Click **Connect Smart Trainer** SECOND. Wait for the success status.
4. Start a ride and verify that both Power/Cadence and BPM telemetry are correctly rendering on the HUD.
(closes #66)