### PR TITLE
fix(ble): enable HR telemetry subscription during active sessions (close #25)

### DIFF
--- a/app.go
+++ b/app.go
@@ -392,14 +392,18 @@ func (a *App) ConnectHeartRate() (string, error) {
 	}
 
 	a.isHRConnected = true
+
+	if a.isRecording {
+		a.trainerService.SubscribeStats(a.telemetryChan)
+	}
+
 	return "HR Monitor Connected", nil
 }
 
 // DisconnectHeartRate explicitly disconnects the HR monitor at the hardware level.
 func (a *App) DisconnectHeartRate() string {
 	if a.isHRConnected && a.trainerService != nil {
-		// Agora sim, manda a antena Bluetooth cortar a conexão!
-		a.trainerService.DisconnectHR() 
+		a.trainerService.DisconnectHR()
 		a.isHRConnected = false
 	}
 	return "Disconnected"
@@ -456,15 +460,12 @@ func (a *App) startSession() string {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancelSim = cancel
 
-	dataChan := make(chan domain.Telemetry)
-
-	// Starts reading data stats
-	if err := a.trainerService.SubscribeStats(dataChan); err != nil {
+	if err := a.trainerService.SubscribeStats(a.telemetryChan); err != nil {
 		cancel()
 		return fmt.Sprintf("Erro Subscribe: %v", err)
 	}
 
-	go a.gameLoop(ctx, dataChan)
+	go a.gameLoop(ctx, a.telemetryChan)
 
 	runtime.EventsEmit(a.ctx, "status_change", "RECORDING")
 	return "Started"

--- a/internal/service/ble/real.go
+++ b/internal/service/ble/real.go
@@ -37,12 +37,11 @@ var (
 	CharHeartRateMeasure    = bluetooth.CharacteristicUUIDHeartRateMeasurement
 	CharControlPoint        = bluetooth.New16BitUUID(0x2A66) // Cycling Power Control Point
 	CharFTMSControl         = bluetooth.New16BitUUID(0x2AD9) // FTMS Control Point
-	
-	// FEC Specific
-	CharFECRead             = bluetooth.New16BitUUID(0xFEC2)
-	CharFECWrite            = bluetooth.New16BitUUID(0xFEC3)
-)
 
+	// FEC Specific
+	CharFECRead  = bluetooth.New16BitUUID(0xFEC2)
+	CharFECWrite = bluetooth.New16BitUUID(0xFEC3)
+)
 
 var (
 	ServiceFEC128, _   = bluetooth.ParseUUID("6e40fec1-b5a3-f393-e0a9-e50e24dcca9e")
@@ -52,7 +51,7 @@ var (
 
 type RealService struct {
 	adapter *bluetooth.Adapter
-	
+
 	trainerDevice *bluetooth.Device
 	hrDevice      *bluetooth.Device
 
@@ -62,11 +61,15 @@ type RealService struct {
 	lastCrankRevs  uint16
 	lastCrankTime  uint16
 	firstCrankRead bool
-	
+
 	isFEC       bool
 	currentMode string // "SIM" ou "ERG"
-	
-	// Controle de Loop FEC
+
+	// Locks to prevent the same device from being registered twice
+	trainerSubscribed bool
+	hrSubscribed      bool
+
+	// FEC Loop Control
 	targetPower  float64
 	targetGrade  float64
 	controlMutex sync.Mutex
@@ -92,38 +95,44 @@ func (s *RealService) ConnectTrainer(onStatus func(string, string)) error {
 	fmt.Println("[BLE] Starting Trainer Scan...")
 
 	ch := make(chan bluetooth.ScanResult)
-	
+
 	go func() {
 		err := s.adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
-			if result.LocalName() == "" { return }
-			if result.HasServiceUUID(ServiceCyclingPower) || 
-			   result.HasServiceUUID(ServiceFitnessMach) || 
-			   result.HasServiceUUID(ServiceFEC) ||
-			   result.HasServiceUUID(ServiceFEC128) {
+			if result.LocalName() == "" {
+				return
+			}
+			if result.HasServiceUUID(ServiceCyclingPower) ||
+				result.HasServiceUUID(ServiceFitnessMach) ||
+				result.HasServiceUUID(ServiceFEC) ||
+				result.HasServiceUUID(ServiceFEC128) {
 				fmt.Printf("[BLE] Trainer Found: %s (%s)\n", result.LocalName(), result.Address.String())
 				adapter.StopScan()
 				ch <- result
 			}
 		})
-		if err != nil { fmt.Println("Scan error:", err) }
+		if err != nil {
+			fmt.Println("Scan error:", err)
+		}
 	}()
 
 	select {
 	case result := <-ch:
 		onStatus("CONNECTING_TRAINER", "Connecting to: "+result.LocalName())
-		
+
 		deviceStruct, err := s.adapter.Connect(result.Address, bluetooth.ConnectionParams{})
-		if err != nil { return fmt.Errorf("connection error: %w", err) }
-		
+		if err != nil {
+			return fmt.Errorf("connection error: %w", err)
+		}
+
 		ptr := new(bluetooth.Device)
 		*ptr = deviceStruct
 		s.trainerDevice = ptr
 		s.firstCrankRead = true
-		
+
 		fmt.Println("[BLE] Trainer Connected.")
 		onStatus("TRAINER_CONNECTED", "Trainer Connected")
 		return nil
-		
+
 	case <-time.After(15 * time.Second):
 		s.adapter.StopScan()
 		return fmt.Errorf("trainer timeout")
@@ -133,7 +142,7 @@ func (s *RealService) ConnectTrainer(onStatus func(string, string)) error {
 func (s *RealService) ConnectHR(onStatus func(string, string)) error {
 	err := s.adapter.Enable()
 	if err != nil {
-    return fmt.Errorf("bluetooth error: %w", err)
+		return fmt.Errorf("bluetooth error: %w", err)
 	}
 
 	onStatus("SCAN_HR", "Searching for HR...")
@@ -149,20 +158,24 @@ func (s *RealService) ConnectHR(onStatus func(string, string)) error {
 				ch <- result
 			}
 		})
-		if err != nil { fmt.Println("Erro scan HR:", err) }
+		if err != nil {
+			fmt.Println("Erro scan HR:", err)
+		}
 	}()
 
 	select {
 	case result := <-ch:
 		onStatus("CONNECTING_HR", "Connecting HR: "+result.LocalName())
-		
+
 		deviceStruct, err := s.adapter.Connect(result.Address, bluetooth.ConnectionParams{})
-		if err != nil { return fmt.Errorf("HR connection error: %w", err) }
-		
+		if err != nil {
+			return fmt.Errorf("HR connection error: %w", err)
+		}
+
 		ptr := new(bluetooth.Device)
 		*ptr = deviceStruct
 		s.hrDevice = ptr
-		
+
 		fmt.Println("[BLE] HR Connected.")
 		onStatus("HR_CONNECTED", "HR Connected: "+result.LocalName())
 		return nil
@@ -180,13 +193,14 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 
 	go func() {
 		// 1. TRAINER
-		if s.trainerDevice != nil {
+		if s.trainerDevice != nil && !s.trainerSubscribed {
+			s.trainerSubscribed = true
 			services, _ := s.trainerDevice.DiscoverServices(nil)
 			for _, service := range services {
 				chars, _ := service.DiscoverCharacteristics(nil)
 				for _, char := range chars {
 					uuid := char.UUID()
-					
+
 					// FEC Data (Notify)
 					if uuid == CharFECRead || uuid == CharFECRead128 {
 						s.isFEC = true
@@ -205,7 +219,7 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 						c := char
 						s.fecWriteChar = &c
 						fmt.Println("[BLE] FEC Control Point Found.")
-						
+
 						// Sequência de Inicialização do Auuki
 						go s.initializeFEC()
 					}
@@ -231,7 +245,8 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 		}
 
 		// 2. HR
-		if s.hrDevice != nil {
+		if s.hrDevice != nil && !s.hrSubscribed {
+			s.hrSubscribed = true
 			services, _ := s.hrDevice.DiscoverServices(nil)
 			for _, service := range services {
 				chars, _ := service.DiscoverCharacteristics(nil)
@@ -253,7 +268,7 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 
 func (s *RealService) initializeFEC() {
 	fmt.Println("[BLE] Initializing FEC Protocol...")
-	
+
 	// 1. User Configuration (Página 55)
 	time.Sleep(1000 * time.Millisecond)
 	msgUser := fec.EncodeUserConfig(75.0, 10.0)
@@ -280,7 +295,9 @@ func (s *RealService) runControlLoop() {
 		case <-s.stopControl:
 			return
 		case <-ticker.C:
-			if s.fecWriteChar == nil || !s.isReady { continue }
+			if s.fecWriteChar == nil || !s.isReady {
+				continue
+			}
 
 			s.controlMutex.Lock()
 			var msg []byte
@@ -308,13 +325,13 @@ func (s *RealService) SetGrade(grade float64) error {
 	}
 
 	s.targetGrade = grade
-	
+
 	if s.isFEC && s.fecWriteChar != nil && s.isReady {
 		msg := fec.EncodeTrackResistance(grade)
 		_, err := s.fecWriteChar.WriteWithoutResponse(msg)
 		return err
 	}
-	return nil 
+	return nil
 }
 
 func (s *RealService) SetPower(watts float64) error {
@@ -343,19 +360,34 @@ func (s *RealService) Disconnect() {
 	case s.stopControl <- struct{}{}:
 	default:
 	}
-	if s.trainerDevice != nil { s.trainerDevice.Disconnect() }
-	if s.hrDevice != nil { s.hrDevice.Disconnect() }
+	if s.trainerDevice != nil {
+		s.trainerDevice.Disconnect()
+	}
+	if s.hrDevice != nil {
+		s.hrDevice.Disconnect()
+	}
+	
+	s.trainerSubscribed = false
+	s.hrSubscribed = false
 	fmt.Println("[BLE] Devices Disconnected")
 }
 
 func (s *RealService) parseCyclingPower(buf []byte) (int16, uint8) {
-	if len(buf) < 4 { return 0, 0 }
+	if len(buf) < 4 {
+		return 0, 0
+	}
 	flags := uint16(buf[0]) | uint16(buf[1])<<8
 	power := int16(uint16(buf[2]) | uint16(buf[3])<<8)
 	offset := 4
-	if flags&0x01 != 0 { offset += 1 }
-	if flags&0x04 != 0 { offset += 2 }
-	if flags&0x10 != 0 { offset += 6 }
+	if flags&0x01 != 0 {
+		offset += 1
+	}
+	if flags&0x04 != 0 {
+		offset += 2
+	}
+	if flags&0x10 != 0 {
+		offset += 6
+	}
 	if flags&0x20 != 0 && len(buf) >= offset+4 {
 		revs := uint16(buf[offset]) | uint16(buf[offset+1])<<8
 		timeVal := uint16(buf[offset+2]) | uint16(buf[offset+3])<<8
@@ -375,15 +407,23 @@ func (s *RealService) calcCadence(revs, timeVal uint16) uint8 {
 	dTime := timeVal - s.lastCrankTime
 	s.lastCrankRevs = revs
 	s.lastCrankTime = timeVal
-	if dTime == 0 { return 0 }
+	if dTime == 0 {
+		return 0
+	}
 	rpm := float64(dRevs) * 1024.0 * 60.0 / float64(dTime)
-	if rpm > 200 || rpm < 0 { return 0 }
+	if rpm > 200 || rpm < 0 {
+		return 0
+	}
 	return uint8(rpm)
 }
 
 func parseHR(buf []byte) uint8 {
-	if len(buf) < 2 { return 0 }
-	if buf[0]&0x01 == 0 { return buf[1] }
+	if len(buf) < 2 {
+		return 0
+	}
+	if buf[0]&0x01 == 0 {
+		return buf[1]
+	}
 	return buf[1]
 }
 
@@ -392,6 +432,7 @@ func (s *RealService) DisconnectHR() {
 	if s.hrDevice != nil {
 		s.hrDevice.Disconnect()
 		s.hrDevice = nil
+		s.hrSubscribed = false // Resets the flag when disconnected
 		fmt.Println("[BLE] HR Device Disconnected")
 	}
 }


### PR DESCRIPTION
### Description (Closes #25)
This PR addresses the bug where connecting a Heart Rate monitor *after* starting a ride resulted in a successful connection but `0` BPM on the UI. 

### Cause & Changes Made
* **Cause:** The `SubscribeStats()` method (which triggers `EnableNotifications` on the BLE characteristic) was only being invoked once at the very beginning of the session (`startSession`). Late-connected devices were paired but never instructed to transmit data.
* **Fix:** 1. Updated `startSession()` to utilize the App's persistent `a.telemetryChan` instead of a discarded local channel.
  2. Injected a check in `ConnectHeartRate()`: if `a.isRecording == true`, it immediately fires `SubscribeStats()` to activate the HR data stream.
  3. Added `trainerSubscribed` and `hrSubscribed` boolean guards in `RealService` to prevent double-subscription crashes when `SubscribeStats()` is called multiple times.

### How to Test
1. Start the Argus Cyclist app.
2. Connect **ONLY** the Smart Trainer.
3. Start a Free Ride (Session begins).
4. Open the Devices Menu and click **Connect Heart Rate**.
5. Return to the HUD and verify that the BPM successfully populates and updates without crashing the active trainer connection.