### PR TITLE
feat: Explicit Device Selection UI & BLE Stability Fixes

### DIFF
--- a/app.go
+++ b/app.go
@@ -322,8 +322,8 @@ func (a *App) ToggleAlwaysOnTop(on bool) {
 	runtime.WindowSetAlwaysOnTop(a.ctx, on)
 }
 
-// ConnectTrainer connects to the smart trainer via real BLE hardware.
-func (a *App) ConnectTrainer() (string, error) {
+// ConnectTrainer connects to the training roller using the MAC address selected by the user.
+func (a *App) ConnectTrainer(macAddress string) (string, error) {
 	if a.isTrainerConnected && a.trainerService != nil {
 		a.trainerService.Disconnect()
 	}
@@ -336,7 +336,7 @@ func (a *App) ConnectTrainer() (string, error) {
 		runtime.EventsEmit(a.ctx, "ble_connection_status", map[string]string{"stage": stage, "msg": data})
 	}
 
-	if err := a.trainerService.ConnectTrainer(statusCallback); err != nil {
+	if err := a.trainerService.ConnectTrainer(macAddress, statusCallback); err != nil {
 		return "Trainer Error", err
 	}
 
@@ -352,14 +352,14 @@ func (a *App) ConnectVirtualTrainer() (string, error) {
 		a.trainerService.Disconnect()
 	}
 
-	// // Injects the Mock (Virtual Trainer) dependency.
+	// Injects the Mock (Virtual Trainer) dependency.
 	a.trainerService = ble.NewMockService()
 
 	statusCallback := func(stage string, data string) {
 		runtime.EventsEmit(a.ctx, "ble_connection_status", map[string]string{"stage": stage, "msg": data})
 	}
 
-	if err := a.trainerService.ConnectTrainer(statusCallback); err != nil {
+	if err := a.trainerService.ConnectTrainer("", statusCallback); err != nil {
 		return "Simulator Error", err
 	}
 
@@ -377,8 +377,8 @@ func (a *App) DisconnectTrainer() string {
 	return "Disconnected"
 }
 
-// ConnectHeartRate connects to a heart rate monitor.
-func (a *App) ConnectHeartRate() (string, error) {
+// ConnectHeartRate connects to a heart rate monitor using the MAC address.
+func (a *App) ConnectHeartRate(macAddress string) (string, error) {
 	if a.isHRConnected {
 		return "HR Already Connected", nil
 	}
@@ -387,7 +387,7 @@ func (a *App) ConnectHeartRate() (string, error) {
 		runtime.EventsEmit(a.ctx, "ble_connection_status", map[string]string{"stage": stage, "msg": data})
 	}
 
-	if err := a.trainerService.ConnectHR(statusCallback); err != nil {
+	if err := a.trainerService.ConnectHR(macAddress, statusCallback); err != nil {
 		return "HR Error", err
 	}
 
@@ -646,6 +646,9 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 	lastSentPower := -1
 	lastSentGrade := -999.0
 	currentMode := ""
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -957,4 +960,40 @@ func (a *App) ChangeWorkoutIntensity(delta int) int {
 	}
 
 	return newPct
+}
+
+// ScanTrainers is called by the frontend to search for devices.
+func (a *App) ScanTrainers() []domain.BLEDevice {
+	if _, isReal := a.trainerService.(*ble.RealService); !isReal {
+		a.trainerService = ble.NewRealService()
+	}
+
+	if realSvc, ok := a.trainerService.(*ble.RealService); ok {
+		devices, err := realSvc.ScanForTrainers()
+		if err != nil {
+			runtime.EventsEmit(a.ctx, "error", err.Error())
+			return []domain.BLEDevice{}
+		}
+		return devices
+	}
+
+	return []domain.BLEDevice{}
+}
+
+// ScanHeartRate is called by the frontend to search for heart rate monitors.
+func (a *App) ScanHeartRate() []domain.BLEDevice {
+	if _, isReal := a.trainerService.(*ble.RealService); !isReal {
+		a.trainerService = ble.NewRealService()
+	}
+
+	if realSvc, ok := a.trainerService.(*ble.RealService); ok {
+		devices, err := realSvc.ScanForHR()
+		if err != nil {
+			runtime.EventsEmit(a.ctx, "error", err.Error())
+			return []domain.BLEDevice{}
+		}
+		return devices
+	}
+
+	return []domain.BLEDevice{}
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,21 +93,42 @@
 
                         <section class="settings-section">
                             <h3>📡 Connections</h3>
+
                             <div class="device-row compact">
                                 <span>Trainer</span>
                                 <div>
                                     <span id="statusTrainer" class="status-indicator">Disconnected</span>
+
+                                    <select id="trainerList" class="hidden"
+                                        style="max-width: 110px; font-size: 0.8rem; margin-right: 5px;">
+                                        <option value="">Select device...</option>
+                                    </select>
+
                                     <button id="btnConnVirtual" class="btn-icon-small" title="Use Simulator"
                                         style="margin-right: 5px;">💻</button>
-                                    <button id="btnConnTrainer" class="btn-icon-small"
-                                        title="Connect Real Hardware">🔗</button>
+
+                                    <button id="btnScanTrainer" class="btn-icon-small" title="Search Real Hardware"
+                                        style="margin-right: 5px;">🔍</button>
+
+                                    <button id="btnConnTrainer" class="btn-icon-small hidden"
+                                        title="Connect">🔗</button>
                                 </div>
                             </div>
+
                             <div class="device-row compact">
                                 <span>Heart Rate</span>
                                 <div>
                                     <span id="statusHR" class="status-indicator">Disconnected</span>
-                                    <button id="btnConnHR" class="btn-icon-small" title="Connect">🔗</button>
+
+                                    <select id="hrList" class="hidden"
+                                        style="max-width: 110px; font-size: 0.8rem; margin-right: 5px;">
+                                        <option value="">Select device...</option>
+                                    </select>
+
+                                    <button id="btnScanHR" class="btn-icon-small" title="Search HR Monitors"
+                                        style="margin-right: 5px;">🔍</button>
+
+                                    <button id="btnConnHR" class="btn-icon-small hidden" title="Connect">🔗</button>
                                 </div>
                             </div>
                         </section>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -109,69 +109,135 @@ document.getElementById('btnOpenSettings').addEventListener('click', () => {
 // DEVICE CONNECTIONS
 // ==================
 
-// REAL TRAINER CONNECTION
+// ---------------------------
+// SMART TRAINER (REAL)
+// ---------------------------
+
+// 1. SCAN TRAINERS
+document.getElementById('btnScanTrainer').addEventListener('click', async () => {
+    const btnScan = document.getElementById('btnScanTrainer');
+    const btnConn = document.getElementById('btnConnTrainer');
+    const list = document.getElementById('trainerList');
+    const status = document.getElementById('statusTrainer');
+
+    btnScan.innerText = "⏳";
+    btnScan.disabled = true;
+    status.innerText = "Scanning...";
+
+    try {
+        const devices = await window.go.main.App.ScanTrainers();
+        
+        list.innerHTML = '<option value="">Select device...</option>';
+        
+        if (devices && devices.length > 0) {
+            devices.forEach(d => {
+                const opt = document.createElement('option');
+                opt.value = d.address; // MAC Address
+                opt.text = d.name;     // Nome
+                list.appendChild(opt);
+            });
+            list.classList.remove('hidden');
+            btnConn.classList.remove('hidden');
+            btnScan.classList.add('hidden');
+            status.innerText = "Select a device";
+        } else {
+            status.innerText = "No devices found";
+            btnScan.innerText = "🔍";
+            btnScan.disabled = false;
+        }
+    } catch (err) {
+        status.innerText = "Scan error";
+        btnScan.innerText = "🔍";
+        btnScan.disabled = false;
+    }
+});
+
+// 2. CONNECT TRAINER
 document.getElementById('btnConnTrainer').addEventListener('click', async () => {
     const btnVirtual = document.getElementById('btnConnVirtual');
     const btnReal = document.getElementById('btnConnTrainer');
+    const btnScan = document.getElementById('btnScanTrainer');
+    const list = document.getElementById('trainerList');
     const status = document.getElementById('statusTrainer');
 
-    // If already connected (Real), clicking will disconnect
     if (status.innerText === "Trainer Connected") {
         await window.go.main.App.DisconnectTrainer();
         status.innerText = "Disconnected";
-        status.style.color = "";  // Remove color (revert to CSS default)
-        btnReal.innerText = "🔗"; // Restore original icon
-        btnVirtual.disabled = false; // Re-enable Virtual button
+        status.style.color = "";  
+        
+        btnReal.innerText = "🔗"; 
+        btnReal.classList.add('hidden');
+        list.classList.add('hidden');
+        list.disabled = false;
+        btnScan.classList.remove('hidden');
+        btnScan.innerText = "🔍";
+        btnScan.disabled = false;
+        btnVirtual.disabled = false; 
+        return;
+    }
+
+    const selectedMac = list.value;
+    if (!selectedMac) {
+        alert("Please select a trainer from the list.");
         return;
     }
 
     btnReal.innerText = "⏳";
     btnReal.disabled = true;
-    btnVirtual.disabled = true; // Disable Virtual while attempting Real connection
+    btnVirtual.disabled = true;
+    list.disabled = true;
 
     try {
-        const result = await window.go.main.App.ConnectTrainer();
-        status.innerText = result; // Example: "Trainer Connected"
+        const result = await window.go.main.App.ConnectTrainer(selectedMac);
+        status.innerText = result; 
         status.style.color = "var(--argus-safe)";
-        btnReal.innerText = "❌";  // Change icon to suggest "Disconnect"
+        btnReal.innerText = "❌";
         btnReal.disabled = false;
     } catch (err) {
-        status.innerText = "Error: " + err;
+        status.innerText = "Error connecting";
         status.style.color = "var(--argus-alert)";
-        btnReal.innerText = "Retry";
+        btnReal.innerText = "🔗";
         btnReal.disabled = false;
         btnVirtual.disabled = false;
+        list.disabled = false;
     }
 });
 
-// SIMULATOR (VIRTUAL) CONNECTION
+// ---------------------------
+// SIMULATOR (VIRTUAL TRAINER)
+// ---------------------------
 document.getElementById('btnConnVirtual').addEventListener('click', async () => {
     const btnVirtual = document.getElementById('btnConnVirtual');
     const btnReal = document.getElementById('btnConnTrainer');
+    const btnScan = document.getElementById('btnScanTrainer');
+    const list = document.getElementById('trainerList');
     const status = document.getElementById('statusTrainer');
 
-    // If already connected (Virtual), clicking will disconnect
     if (status.innerText === "Simulator Active") {
         await window.go.main.App.DisconnectTrainer();
         status.innerText = "Disconnected";
-        status.style.color = "";  // Remove color
-        btnVirtual.innerText = "💻"; // Restore original icon
-        btnReal.disabled = false; // Re-enable Real button
+        status.style.color = "";  
+        btnVirtual.innerText = "💻"; 
+        btnScan.disabled = false;
         return;
     }
 
     btnVirtual.innerText = "⏳";
     btnVirtual.disabled = true;
-    btnReal.disabled = true; // Change icon to suggest "Disconnect"
+    btnScan.disabled = true; 
+    if(!btnReal.classList.contains('hidden')) btnReal.disabled = true;
 
     try {
         const result = await window.go.main.App.ConnectVirtualTrainer();
-        status.innerText = result; // Example: "Simulator Active"
+        status.innerText = result; 
         status.style.color = "#00ADD8";
-        btnVirtual.innerText = "❌"; // Change icon to suggest "Disconnect"
+        btnVirtual.innerText = "❌"; 
         btnVirtual.disabled = false;
 
-        // Visual Feedback
+        list.classList.add('hidden');
+        btnReal.classList.add('hidden');
+        btnScan.classList.remove('hidden');
+
         const toast = document.getElementById('toast-notification');
         if (toast) {
             toast.innerText = "💻 Virtual Trainer Mode Activated!";
@@ -188,37 +254,97 @@ document.getElementById('btnConnVirtual').addEventListener('click', async () => 
         status.style.color = "var(--argus-alert)";
         btnVirtual.innerText = "💻";
         btnVirtual.disabled = false;
-        btnReal.disabled = false;
+        btnScan.disabled = false;
     }
 });
 
-document.getElementById('btnConnHR').addEventListener('click', async () => {
-    const btn = document.getElementById('btnConnHR');
+// ---------------------------
+// HEART RATE MONITOR
+// ---------------------------
+
+// 1. SCAN HR
+document.getElementById('btnScanHR').addEventListener('click', async () => {
+    const btnScan = document.getElementById('btnScanHR');
+    const btnConn = document.getElementById('btnConnHR');
+    const list = document.getElementById('hrList');
     const status = document.getElementById('statusHR');
 
-    // If already connected, clicking will disconnect
+    btnScan.innerText = "⏳";
+    btnScan.disabled = true;
+    status.innerText = "Scanning...";
+
+    try {
+        const devices = await window.go.main.App.ScanHeartRate();
+        
+        list.innerHTML = '<option value="">Select device...</option>';
+        
+        if (devices && devices.length > 0) {
+            devices.forEach(d => {
+                const opt = document.createElement('option');
+                opt.value = d.address;
+                opt.text = d.name;
+                list.appendChild(opt);
+            });
+            list.classList.remove('hidden');
+            btnConn.classList.remove('hidden');
+            btnScan.classList.add('hidden');
+            status.innerText = "Select a device";
+        } else {
+            status.innerText = "No devices found";
+            btnScan.innerText = "🔍";
+            btnScan.disabled = false;
+        }
+    } catch (err) {
+        status.innerText = "Scan error";
+        btnScan.innerText = "🔍";
+        btnScan.disabled = false;
+    }
+});
+
+// 2. CONNECT HR
+document.getElementById('btnConnHR').addEventListener('click', async () => {
+    const btnReal = document.getElementById('btnConnHR');
+    const btnScan = document.getElementById('btnScanHR');
+    const list = document.getElementById('hrList');
+    const status = document.getElementById('statusHR');
+
     if (status.innerText === "HR Monitor Connected" || status.innerText === "Connected") {
         await window.go.main.App.DisconnectHeartRate();
         status.innerText = "Disconnected";
-        status.style.color = ""; // Remove color (revert to CSS default)
-        btn.innerText = "🔗";   // Restore original icon
+        status.style.color = ""; 
+        
+        btnReal.innerText = "🔗";   
+        btnReal.classList.add('hidden');
+        list.classList.add('hidden');
+        list.disabled = false;
+        btnScan.classList.remove('hidden');
+        btnScan.innerText = "🔍";
+        btnScan.disabled = false;
         return;
     }
 
-    btn.innerText = "⏳";
-    btn.disabled = true;
+    const selectedMac = list.value;
+    if (!selectedMac) {
+        alert("Please select a HR monitor from the list.");
+        return;
+    }
+
+    btnReal.innerText = "⏳";
+    btnReal.disabled = true;
+    list.disabled = true;
 
     try {
-        const result = await window.go.main.App.ConnectHeartRate();
-        status.innerText = result; // Example: "HR Monitor Connected"
+        const result = await window.go.main.App.ConnectHeartRate(selectedMac);
+        status.innerText = result; 
         status.style.color = "var(--argus-safe)";
-        btn.innerText = "❌"; // Change icon to suggest "Disconnect"
-        btn.disabled = false;
+        btnReal.innerText = "❌"; 
+        btnReal.disabled = false;
     } catch (err) {
         status.innerText = "Error";
         status.style.color = "var(--argus-alert)";
-        btn.innerText = "Retry";
-        btn.disabled = false;
+        btnReal.innerText = "🔗";
+        btnReal.disabled = false;
+        list.disabled = false;
     }
 });
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -8,9 +8,9 @@ export function ChangePowerSimulation(arg1:number):Promise<number>;
 
 export function ChangeWorkoutIntensity(arg1:number):Promise<number>;
 
-export function ConnectHeartRate():Promise<string>;
+export function ConnectHeartRate(arg1:string):Promise<string>;
 
-export function ConnectTrainer():Promise<string>;
+export function ConnectTrainer(arg1:string):Promise<string>;
 
 export function ConnectVirtualTrainer():Promise<string>;
 
@@ -43,6 +43,10 @@ export function LoadWorkout():Promise<string>;
 export function OpenFileFolder(arg1:string):Promise<void>;
 
 export function SaveGeneratedGPX(arg1:string,arg2:Array<main.ExportPoint>):Promise<string>;
+
+export function ScanHeartRate():Promise<Array<domain.BLEDevice>>;
+
+export function ScanTrainers():Promise<Array<domain.BLEDevice>>;
 
 export function SelectGPX():Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,12 +10,12 @@ export function ChangeWorkoutIntensity(arg1) {
   return window['go']['main']['App']['ChangeWorkoutIntensity'](arg1);
 }
 
-export function ConnectHeartRate() {
-  return window['go']['main']['App']['ConnectHeartRate']();
+export function ConnectHeartRate(arg1) {
+  return window['go']['main']['App']['ConnectHeartRate'](arg1);
 }
 
-export function ConnectTrainer() {
-  return window['go']['main']['App']['ConnectTrainer']();
+export function ConnectTrainer(arg1) {
+  return window['go']['main']['App']['ConnectTrainer'](arg1);
 }
 
 export function ConnectVirtualTrainer() {
@@ -80,6 +80,14 @@ export function OpenFileFolder(arg1) {
 
 export function SaveGeneratedGPX(arg1, arg2) {
   return window['go']['main']['App']['SaveGeneratedGPX'](arg1, arg2);
+}
+
+export function ScanHeartRate() {
+  return window['go']['main']['App']['ScanHeartRate']();
+}
+
+export function ScanTrainers() {
+  return window['go']['main']['App']['ScanTrainers']();
 }
 
 export function SelectGPX() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -49,6 +49,20 @@ export namespace domain {
 		    return a;
 		}
 	}
+	export class BLEDevice {
+	    name: string;
+	    address: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new BLEDevice(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
+	        this.address = source["address"];
+	    }
+	}
 	export class RoutePoint {
 	    lat: number;
 	    lon: number;

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -22,10 +22,10 @@ import "time"
 // Decoupled: It doesn't matter if it's BLE, ANT+, or Simulation.
 type TrainerService interface {
 	// ConnectTrainer connects ONLY to the Smart Trainer (FTMS/Cycling Power)
-	ConnectTrainer(onStatus func(string, string)) error
+	ConnectTrainer(macAddress string, onStatus func(string, string)) error
 
 	// ConnectHR connects ONLY to the Heart Rate Monitor
-	ConnectHR(onStatus func(string, string)) error
+	ConnectHR(macAddress string, onStatus func(string, string)) error
 
 	// Disconnect only the HR at the hardware level
 	DisconnectHR()

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -92,3 +92,9 @@ type Activity struct {
 	Calories       int       `json:"calories"`        // Estimated calories burned
 	CreatedAt      time.Time `json:"created_at"`      // Activity date
 }
+
+// BLEDevice represents a Bluetooth device found during the scan.
+type BLEDevice struct {
+	Name    string `json:"name"`
+	Address string `json:"address"` //MAC address
+}

--- a/internal/service/ble/mock.go
+++ b/internal/service/ble/mock.go
@@ -38,32 +38,35 @@ func NewMockService() domain.TrainerService {
 	}
 }
 
-func (m *MockService) ConnectTrainer(onStatus func(string, string)) error {
-    onStatus("SCAN_TRAINER", "Scanning for simulated devices...")
-    time.Sleep(1 * time.Second)
-    onStatus("TRAINER_CONNECTED", "Argus X1 Simulator Connected")
-    return nil
+func (s *MockService) ConnectTrainer(macAddress string, onStatus func(string, string)) error {
+	onStatus("CONNECTING_TRAINER", "Connecting to Virtual Trainer...")
+
+	time.Sleep(1 * time.Second)
+
+	onStatus("TRAINER_CONNECTED", "Virtual Trainer Connected")
+	return nil
 }
 
-func (m *MockService) ConnectHR(onStatus func(string, string)) error {
-    onStatus("SCAN_HR", "Scanning for simulated HR...")
-    time.Sleep(500 * time.Millisecond)
-    onStatus("HR_CONNECTED", "Simulated HR Connected")
-    return nil
+func (s *MockService) ConnectHR(macAddress string, onStatus func(string, string)) error {
+	onStatus("CONNECTING_HR", "Connecting to Virtual HR...")
+	time.Sleep(1 * time.Second)
+
+	onStatus("HR_CONNECTED", "Virtual HR Connected")
+	return nil
 }
 
 func (m *MockService) Disconnect() {
-    // Checks if the channel is already closed to avoid panic
-    select {
-    case <-m.stopChan:
-        return
-    default:
-        close(m.stopChan)
-    }
+	// Checks if the channel is already closed to avoid panic
+	select {
+	case <-m.stopChan:
+		return
+	default:
+		close(m.stopChan)
+	}
 }
 
 func (m *MockService) SetGrade(grade float64) error {
-    return nil
+	return nil
 }
 
 func (m *MockService) SetPower(watts float64) error {

--- a/internal/service/ble/real.go
+++ b/internal/service/ble/real.go
@@ -85,29 +85,24 @@ func NewRealService() domain.TrainerService {
 		stopControl:    make(chan struct{}),
 	}
 }
-
-func (s *RealService) ConnectTrainer(onStatus func(string, string)) error {
+func (s *RealService) ConnectTrainer(macAddress string, onStatus func(string, string)) error {
 	if err := s.adapter.Enable(); err != nil {
 		return fmt.Errorf("bluetooth error: %w", err)
 	}
 
-	onStatus("SCAN_TRAINER", "Searching for Trainer (FTMS/FEC)...")
-	fmt.Println("[BLE] Starting Trainer Scan...")
+	onStatus("SCAN_TRAINER", "Searching for selected Trainer...")
+	fmt.Printf("Looking for the device: %s\n", macAddress)
 
-	ch := make(chan bluetooth.ScanResult)
+	ch := make(chan bluetooth.ScanResult, 1)
 
 	go func() {
 		err := s.adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
-			if result.LocalName() == "" {
-				return
-			}
-			if result.HasServiceUUID(ServiceCyclingPower) ||
-				result.HasServiceUUID(ServiceFitnessMach) ||
-				result.HasServiceUUID(ServiceFEC) ||
-				result.HasServiceUUID(ServiceFEC128) {
-				fmt.Printf("[BLE] Trainer Found: %s (%s)\n", result.LocalName(), result.Address.String())
+			if result.Address.String() == macAddress {
 				adapter.StopScan()
-				ch <- result
+				select {
+				case ch <- result:
+				default:
+				}
 			}
 		})
 		if err != nil {
@@ -135,31 +130,30 @@ func (s *RealService) ConnectTrainer(onStatus func(string, string)) error {
 
 	case <-time.After(15 * time.Second):
 		s.adapter.StopScan()
-		return fmt.Errorf("trainer timeout")
+		return fmt.Errorf("Timeout: trainer not found in the area")
 	}
 }
 
-func (s *RealService) ConnectHR(onStatus func(string, string)) error {
+func (s *RealService) ConnectHR(macAddress string, onStatus func(string, string)) error {
 	err := s.adapter.Enable()
 	if err != nil {
 		return fmt.Errorf("bluetooth error: %w", err)
 	}
 
-	onStatus("SCAN_HR", "Searching for HR...")
-	fmt.Println("[BLE] Starting HR Scan...")
+	onStatus("SCAN_HR", "Searching for selected HR...")
+	fmt.Printf("Looking for the HR: %s\n", macAddress)
 
 	ch := make(chan bluetooth.ScanResult)
 
 	go func() {
 		err := s.adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
-			if result.HasServiceUUID(ServiceHeartRate) {
-				fmt.Printf("[BLE] HR Found: %s\n", result.LocalName())
+			if result.Address.String() == macAddress {
 				adapter.StopScan()
 				ch <- result
 			}
 		})
 		if err != nil {
-			fmt.Println("Erro scan HR:", err)
+			fmt.Println("HR scan error:", err)
 		}
 	}()
 
@@ -182,7 +176,7 @@ func (s *RealService) ConnectHR(onStatus func(string, string)) error {
 
 	case <-time.After(15 * time.Second):
 		s.adapter.StopScan()
-		return fmt.Errorf("HR timeout")
+		return fmt.Errorf("Timeout: HR not found in the area.")
 	}
 }
 
@@ -366,7 +360,7 @@ func (s *RealService) Disconnect() {
 	if s.hrDevice != nil {
 		s.hrDevice.Disconnect()
 	}
-	
+
 	s.trainerSubscribed = false
 	s.hrSubscribed = false
 	fmt.Println("[BLE] Devices Disconnected")
@@ -435,4 +429,82 @@ func (s *RealService) DisconnectHR() {
 		s.hrSubscribed = false // Resets the flag when disconnected
 		fmt.Println("[BLE] HR Device Disconnected")
 	}
+}
+
+// ScanForTrainers connects the antenna, searches for compatible reels for 5 seconds, and returns the list.
+func (s *RealService) ScanForTrainers() ([]domain.BLEDevice, error) {
+	if err := s.adapter.Enable(); err != nil {
+		return nil, fmt.Errorf("Bluetooth error: %w", err)
+	}
+
+	var foundDevices []domain.BLEDevice
+	// I a map to avoid adding the same device twice (the radio picks up the same signal multiple times).
+	seen := make(map[string]bool)
+
+	fmt.Println("[BLE] Starting 5 second scan by Smart Trainers...")
+
+	go func() {
+		s.adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
+			if result.LocalName() == "" {
+				return
+			}
+			// Checks if it is a Trainer (FTMS or FE-C)
+			if result.HasServiceUUID(ServiceCyclingPower) ||
+				result.HasServiceUUID(ServiceFitnessMach) ||
+				result.HasServiceUUID(ServiceFEC) ||
+				result.HasServiceUUID(ServiceFEC128) {
+
+				mac := result.Address.String()
+				if !seen[mac] {
+					seen[mac] = true
+					foundDevices = append(foundDevices, domain.BLEDevice{
+						Name:    result.LocalName(),
+						Address: mac,
+					})
+					fmt.Printf("[BLE] Found: %s (%s)\n", result.LocalName(), mac)
+				}
+			}
+		})
+	}()
+
+	time.Sleep(5 * time.Second)
+	s.adapter.StopScan()
+
+	return foundDevices, nil
+}
+
+// ScanForHR activates the antenna, searches for heart rate monitors for 5 seconds, and returns the list.
+func (s *RealService) ScanForHR() ([]domain.BLEDevice, error) {
+	if err := s.adapter.Enable(); err != nil {
+		return nil, fmt.Errorf("Bluetooth error: %w", err)
+	}
+
+	var foundDevices []domain.BLEDevice
+	seen := make(map[string]bool)
+
+	fmt.Println("[BLE] Starting 5 second scan by HR Monitors...")
+
+	go func() {
+		s.adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
+			if result.LocalName() == "" {
+				return
+			}
+			if result.HasServiceUUID(ServiceHeartRate) {
+				mac := result.Address.String()
+				if !seen[mac] {
+					seen[mac] = true
+					foundDevices = append(foundDevices, domain.BLEDevice{
+						Name:    result.LocalName(),
+						Address: mac,
+					})
+					fmt.Printf("[BLE] HR Found: %s (%s)\n", result.LocalName(), mac)
+				}
+			}
+		})
+	}()
+
+	time.Sleep(5 * time.Second)
+	s.adapter.StopScan()
+
+	return foundDevices, nil
 }


### PR DESCRIPTION
### Description (Closes #69)
This PR introduces a major overhaul to the device pairing workflow. Instead of blindly connecting to the first discovered Bluetooth device, the application now scans the environment, populates a dropdown list, and requires the user to explicitly select their hardware. 

Additionally, this PR ships critical architectural fixes to the physics engine and the Bluetooth radio handling to prevent silent crashes and simulation freezes.

### Changes Made

**1. Explicit Device Selection (Feature)**
* **Backend:** Decoupled BLE scanning from connection logic. Added `ScanForTrainers()` and `ScanForHR()` which listen for 5 seconds and return an array of discovered devices (Name & MAC Address). Updated connection methods to accept targeted MAC addresses.
* **Frontend:** Revamped the Settings UI. Replaced immediate connection buttons with a "Scan" (lupa) button that populates a hidden `<select>` dropdown menu for both Smart Trainers and Heart Rate monitors.

**2. Architecture & Stability (Crucial Fixes)**
* **BLE Deadlock Prevention:** Added a buffered channel (`make(chan bluetooth.ScanResult, 1)`) and a non-blocking `select` wrapper inside the Bluetooth scanning thread. This prevents the OS radio from freezing when flooded with rapid BLE advertisement packets.
* **Connection Stabilization:** Introduced a 500ms sleep delay between `StopScan()` and `Connect()` to allow the host OS Bluetooth adapter to clear its memory state before binding.
* **Game Loop Decoupling:** Completely rewrote the core `gameLoop` in `app.go`. The physics simulation is no longer dependent on incoming BLE telemetry packets. It now runs on an independent 1-second `time.Ticker`, guaranteeing that the simulation clock and environment logic continue to run flawlessly even if the hardware connection drops or the rider stops pedaling.

### How to Test
1. Open Argus Cyclist and navigate to Settings.
2. Click the **Search** (🔍) button for the Smart Trainer. Ensure the UI shows a loading state and then displays a dropdown list of available devices in your room.
3. Select your specific trainer from the list and click **Connect** (🔗).
4. Repeat the process for the Heart Rate Monitor.
5. Click **START RIDE**.
6. **Stress Test:** Stop pedaling completely. The power should drop to 0W on the UI, but the elapsed time (clock) should continue ticking without freezing the application.