### PR TITLE
feat: support deleting activities from history (#74)

### DIFF
--- a/app.go
+++ b/app.go
@@ -1049,3 +1049,26 @@ func (a *App) GetCareerDashboard() (CareerDashboard, error) {
 		MMP: mmpData,
 	}, nil
 }
+
+// DeleteActivityHistory deletes the workout from the database and removes the .fit file from disk
+func (a *App) DeleteActivityHistory(activityID uint) error {
+	// 1. Fetch the activity to discover the associated .fit filename
+	activity, err := a.storageService.GetActivityByID(activityID)
+	if err != nil {
+		return fmt.Errorf("activity not found: %v", err)
+	}
+
+	// 2. Delete the record from the SQLite database
+	err = a.storageService.DeleteActivity(activityID)
+	if err != nil {
+		return fmt.Errorf("error deleting from database: %v", err)
+	}
+
+	// 3. Delete the physical .fit file from the user's disk
+	// If the file does not exist (e.g., manually deleted), the function ignores the error
+	if activity.Filename != "" {
+		_ = os.Remove(activity.Filename)
+	}
+
+	return nil
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -200,9 +200,12 @@
                 <div class="history-list">
                     <div class="history-item history-header">
                         <span style="flex: 2;">Date / Route</span>
-                        <span style="flex: 1;">Dist</span>
-                        <span style="flex: 1;">Avg Pwr</span>
-                        <span style="width: 40px;">File</span>
+
+                        <span style="flex: 1; text-align: center;">Dist</span>
+
+                        <span style="flex: 1; text-align: center;">Avg Pwr</span>
+
+                        <span style="width: 80px; text-align: center;">Actions</span>
                     </div>
                     <div id="historyContainer">
                         <div class="history-item"><span>Loading...</span></div>

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -175,7 +175,7 @@ export class UIManager {
             const lapDist = data.total_dist % totalRouteDistance;
             const remainingMeters = Math.max(0, totalRouteDistance - lapDist);
             const remObj = this.formatDist(remainingMeters);
-            
+
             const currentLap = Math.floor(data.total_dist / totalRouteDistance) + 1;
 
             this.els.distRem.innerHTML = `${remObj.val}<span class="data-unit">${remObj.unit} (L${currentLap})</span>`;
@@ -485,18 +485,38 @@ export class UIManager {
                 this.openActivityDetail(act);
             };
 
+            // We add a flex container for the folder icon and the trash icon
             div.innerHTML = `
-                <span style="flex: 2;">${date} - <small style="color: #aaa;">${name}</small></span>
-                <span style="flex: 1;">${dist}</span>
-                <span style="flex: 1; color: var(--power-color, #f1c40f); font-weight: bold;">${pwr}w</span>
-                <span 
-                    title="Abrir Pasta" 
-                    style="width: 40px; text-align: center; font-size: 1.2rem; cursor: pointer;"
-                    onclick="event.stopPropagation(); window.go.main.App.OpenFileFolder('${safeFilename}')"
-                >
-                    📂
-                </span>
-            `;
+    <span style="flex: 2;">${date} - <small style="color: var(--text-muted);">${name}</small></span>
+    
+    <span style="flex: 1; text-align: center;">${dist}</span>
+    
+    <span style="flex: 1; text-align: center; color: var(--power-color); font-weight: bold;">${pwr}w</span>
+    
+    <div style="display: flex; gap: 15px; width: 80px; justify-content: center; align-items: center;">
+        <span 
+            title="Open Folder" 
+            style="font-size: 1.2rem; cursor: pointer; transition: transform 0.2s;"
+            onmouseover="this.style.transform='scale(1.2)'"
+            onmouseout="this.style.transform='scale(1)'"
+            onclick="event.stopPropagation(); window.go.main.App.OpenFileFolder('${safeFilename}')"
+        >📂</span>
+        
+        <span 
+            title="Delete Workout" 
+            style="font-size: 1.2rem; cursor: pointer; transition: transform 0.2s;"
+            onmouseover="this.style.transform='scale(1.2)'"
+            onmouseout="this.style.transform='scale(1)'"
+            onclick="event.stopPropagation(); if(confirm('Are you sure you want to delete this workout? Statistics will be recalculated and the file will be removed from disk.')) { 
+                const targetId = ${act.ID ? act.ID : act.id};
+                window.go.main.App.DeleteActivityHistory(targetId).then(() => {
+                    window.ui.toggleSettings(true);
+                    window.ui.loadCareerDashboard(); 
+                }).catch(err => alert('Error deleting: ' + err)); 
+            }"
+        >🗑️</span>
+    </div>
+`;
 
             this.els.historyContainer.appendChild(div);
         });

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -630,8 +630,9 @@ footer {
 
 /* --- DASHBOARD & HISTORY --- */
 .settings-content {
-    max-width: 800px;
     width: 90%;
+    max-width: 1000px;
+    padding: 25px 30px;
 }
 
 .tabs {
@@ -678,13 +679,12 @@ footer {
 }
 
 .history-item {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1fr 40px;
-    padding: 12px 14px;
-    font-size: 0.9rem;
+    display: flex;
+    justify-content: space-between;
     align-items: center;
+    padding: 10px 20px;
     border-bottom: 1px solid var(--border-color);
-    transition: background 0.2s ease;
+    transition: background-color 0.2s;
 }
 
 .history-item:hover {
@@ -1583,7 +1583,7 @@ TACTICAL BLUE
     --text-muted: #94a3b8;
     --border-color: #1a1a1a;
 
-    --power-color: #38bdf8; 
+    --power-color: #38bdf8;
 
     --chart-bg: #000000;
     --chart-fill: rgba(0, 136, 255, 0.15);
@@ -1604,12 +1604,18 @@ TACTICAL BLUE
    ========================================= */
 
 :root {
-    --zone-1: #7f8c8d; /* Active Recovery */
-    --zone-2: #3498db; /* Endurance */
-    --zone-3: #2ecc71; /* Tempo */
-    --zone-4: #f1c40f; /* Threshold */
-    --zone-5: #e67e22; /* VO2 Max */
-    --zone-6: #e74c3c; /* Anaerobic */
+    --zone-1: #7f8c8d;
+    /* Active Recovery */
+    --zone-2: #3498db;
+    /* Endurance */
+    --zone-3: #2ecc71;
+    /* Tempo */
+    --zone-4: #f1c40f;
+    /* Threshold */
+    --zone-5: #e67e22;
+    /* VO2 Max */
+    --zone-6: #e74c3c;
+    /* Anaerobic */
 }
 
 .finish-stats-grid {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -15,6 +15,8 @@ export function ConnectTrainer(arg1:string):Promise<string>;
 
 export function ConnectVirtualTrainer():Promise<string>;
 
+export function DeleteActivityHistory(arg1:number):Promise<void>;
+
 export function DiscardSession():Promise<string>;
 
 export function DisconnectDevice():Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -22,6 +22,10 @@ export function ConnectVirtualTrainer() {
   return window['go']['main']['App']['ConnectVirtualTrainer']();
 }
 
+export function DeleteActivityHistory(arg1) {
+  return window['go']['main']['App']['DeleteActivityHistory'](arg1);
+}
+
 export function DiscardSession() {
   return window['go']['main']['App']['DiscardSession']();
 }

--- a/internal/service/storage/service.go
+++ b/internal/service/storage/service.go
@@ -196,3 +196,16 @@ func (s *Service) GetPowerRecords() ([]PowerRecord, error) {
 	err := s.db.Order("duration asc").Find(&records).Error
 	return records, err
 }
+
+// GetActivityByID returns a specific activity by its ID.
+func (s *Service) GetActivityByID(id uint) (domain.Activity, error) {
+	var activity domain.Activity
+	err := s.db.First(&activity, id).Error
+	return activity, err
+}
+
+// DeleteActivity removes the activity record from the database.
+func (s *Service) DeleteActivity(id uint) error {
+	// GORM needs to know which model to use to delete the correct row
+	return s.db.Delete(&domain.Activity{}, id).Error
+}


### PR DESCRIPTION
## Description
This PR resolves issue #74  by allowing users to delete specific activities from their history. 

Previously, test rides or aborted workouts would permanently skew the user's career statistics and Performance Management Chart (PMC). Now, users can remove unwanted sessions, which will dynamically recalculate all stats and keep the dashboard clean.

Resolves #74 

## Changes Made
- **Backend (`service.go`)**: Added `GetActivityByID` and `DeleteActivity` functions to handle SQLite database record removal.
- **Backend (`app.go`)**: Implemented `DeleteActivityHistory(id)`, which orchestrates the database deletion and also uses `os.Remove()` to clean up the associated `.fit` file from the local disk.
- **Frontend (`UIManager.js`)**: 
  - Added a trash/delete icon to the `renderActivityList` function.
  - Implemented a `window.confirm` safety prompt to prevent accidental deletions.
  - Bound the deletion success response to trigger an automatic UI refresh (`toggleSettings(true)` and `loadCareerDashboard()`) so the charts and totals update instantly.
- **Frontend (`index.html` & `main.css`)**: Adjusted the history table layout widths to comfortably fit the new action buttons without overlapping.

## Testing Instructions
1. Navigate to the **History & Stats** tab in the settings menu.
2. Identify a test or unwanted activity.
3. Click the 🗑️ (Trash) icon next to the activity.
4. Verify that the confirmation dialog appears. Cancel to ensure it aborts properly.
5. Click it again and confirm the deletion.
6. Verify that:
   - The activity disappears from the list.
   - The "Total Distance" and "Total Time" stats decrease accordingly.
   - The PMC chart on the **Career Dashboard** tab recalculates.
   - The physical `.fit` file is actually removed from your local storage folder.