### PR TITLE
feat(#85): implement offline dashboard mode and live telemetry chart

### DIFF
--- a/app.go
+++ b/app.go
@@ -681,7 +681,15 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 		case rawData := <-input:
 			if rawData.Power != -1 {
 				currentPower = rawData.Power
-				currentCadence = rawData.Cadence
+				
+				// FILTER: Ignores Cadence = 0 if it's just an empty BLE data page.
+				// It only drops to 0 if the cyclist actually stops pedaling (Power == 0).
+				if rawData.Cadence > 0 {
+					currentCadence = rawData.Cadence
+				} else if currentPower == 0 {
+					currentCadence = 0
+				}
+				
 				lastPowerTime = time.Now()
 			}
 			if rawData.HeartRate > 0 {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,8 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no">
     <title>Argus Cyclist</title>
 </head>
 
@@ -100,17 +101,37 @@
                                     </select>
 
                                     <button id="btnConnVirtual" class="btn-icon-small" title="Use Simulator"
-                                        style="margin-right: 5px;">💻</button>
+                                        style="margin-right: 5px;">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                            stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                            stroke-linejoin="round">
+                                            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+                                            <line x1="2" y1="20" x2="22" y2="20"></line>
+                                        </svg>
+                                    </button>
 
                                     <button id="btnScanTrainer" class="btn-icon-small" title="Search Real Hardware"
-                                        style="margin-right: 5px;">🔍</button>
+                                        style="margin-right: 5px;">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                            stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                            stroke-linejoin="round">
+                                            <circle cx="11" cy="11" r="8"></circle>
+                                            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                                        </svg>
+                                    </button>
 
-                                    <button id="btnConnTrainer" class="btn-icon-small hidden"
-                                        title="Connect">🔗</button>
+                                    <button id="btnConnTrainer" class="btn-icon-small hidden" title="Connect">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                            stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                            stroke-linejoin="round">
+                                            <polyline points="6.5 6.5 17.5 17.5 12 23 12 1 17.5 6.5 6.5 17.5">
+                                            </polyline>
+                                        </svg>
+                                    </button>
                                 </div>
                             </div>
 
-                            <div class="device-row compact">
+                           <div class="device-row compact">
                                 <span>Heart Rate</span>
                                 <div>
                                     <span id="statusHR" class="status-indicator">Disconnected</span>
@@ -121,9 +142,36 @@
                                     </select>
 
                                     <button id="btnScanHR" class="btn-icon-small" title="Search HR Monitors"
-                                        style="margin-right: 5px;">🔍</button>
+                                        style="margin-right: 5px;">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" 
+                                            stroke="currentColor" stroke-width="2" stroke-linecap="round" 
+                                            stroke-linejoin="round">
+                                            <circle cx="11" cy="11" r="8"></circle>
+                                            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                                        </svg>
+                                    </button>
 
-                                    <button id="btnConnHR" class="btn-icon-small hidden" title="Connect">🔗</button>
+                                    <button id="btnConnHR" class="btn-icon-small hidden" title="Connect"
+                                        style="margin-right: 5px;">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                            stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                            stroke-linejoin="round">
+                                            <polyline points="6.5 6.5 17.5 17.5 12 23 12 1 17.5 6.5 6.5 17.5">
+                                            </polyline>
+                                        </svg>
+                                    </button>
+
+                                    <button id="btnWaitHR" class="btn-icon-small hidden" title="Waiting..." 
+                                        style="margin-right: 5px; opacity: 0.5; cursor: wait;">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" 
+                                            stroke="currentColor" stroke-width="2" stroke-linecap="round" 
+                                            stroke-linejoin="round">
+                                            <path d="M5 22h14"></path>
+                                            <path d="M5 2h14"></path>
+                                            <path d="M14 22V18.13a4 4 0 0 0-1.17-2.83L12 14.4l-1.83.9A4 4 0 0 0 9 18.13V22"></path>
+                                            <path d="M14 2v3.87a4 4 0 0 1-1.17 2.83L12 9.6l-1.83-.9A4 4 0 0 1 9 5.87V2"></path>
+                                        </svg>
+                                    </button>
                                 </div>
                             </div>
                         </section>
@@ -253,6 +301,12 @@
     <header>
         <div class="brand">ARGUS<span>CYCLIST</span> <span id="filename" class="filename-display"></span></div>
         <div class="header-controls">
+            <button class="btn-icon" id="btnToggleView" title="Toggle Dashboard View">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+                </svg>
+            </button>
             <button class="btn-icon" id="btnOpenSettings" title="Settings">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="12" cy="12" r="3"></circle>
@@ -324,6 +378,51 @@
         </aside>
 
         <main id="map-container"></main>
+
+        <div id="dashboard-view" class="dashboard-container hidden">
+            <div class="dash-layout">
+
+                <div class="dash-metrics-row">
+                    <div class="dash-card power-card">
+                        <span class="dash-label">POWER</span>
+                        <div class="dash-value" id="dash-power">0<span class="dash-unit">w</span></div>
+                        <div class="dash-sub" id="dash-wkg" style="color: var(--power-color)">0.0 w/kg</div>
+                    </div>
+                    <div class="dash-card hr-card">
+                        <span class="dash-label">HEART RATE</span>
+                        <div class="dash-value" id="dash-hr">--<span class="dash-unit">bpm</span></div>
+                    </div>
+                    <div class="dash-card">
+                        <span class="dash-label">CADENCE</span>
+                        <div class="dash-value" id="dash-rpm">0<span class="dash-unit">rpm</span></div>
+                    </div>
+                    <div class="dash-card">
+                        <span class="dash-label">SPEED</span>
+                        <div class="dash-value" id="dash-speed">0.0<span class="dash-unit">km/h</span></div>
+                    </div>
+                    <div class="dash-card">
+                        <span class="dash-label">DISTANCE</span>
+                        <div class="dash-value" id="dash-dist">0.0<span class="dash-unit">km</span></div>
+                    </div>
+                    <div class="dash-card">
+                        <span class="dash-label">TIME</span>
+                        <div class="dash-value" id="dash-time">00:00:00</div>
+                    </div>
+                </div>
+
+                <div class="dash-chart-section">
+                    <div class="dash-chart-header">
+                        <h3
+                            style="margin: 0; color: var(--text-muted); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 1px;">
+                            Live Telemetry</h3>
+                    </div>
+                    <div class="dash-chart-body">
+                        <div id="liveDashboardChart" style="width: 100%; height: 100%;"></div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
 
         <aside id="workout-panel" class="hud-sidebar right-panel hidden">
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -15,7 +15,7 @@ import { UIManager } from './modules/UIManager.js';
 import { ElevationChart } from './modules/ElevationChart.js';
 import { WorkoutController } from './modules/WorkoutController.js';
 
-// Importações do Capacitor para a versão Mobile
+// Capacitor imports for the Mobile version
 import { Capacitor } from '@capacitor/core';
 import { CapacitorBluetoothService } from './modules/CapacitorBluetoothService.js';
 
@@ -26,14 +26,14 @@ if (typeof window.go === 'undefined') {
     window.go = {
         main: {
             App: new Proxy({}, {
-                get: function(target, prop) {
+                get: function (target, prop) {
                     if (prop === 'GetUserProfile') return async () => ({ name: "Mobile", weight: 75, bike_weight: 9, ftp: 200, units: "metric" });
                     if (prop === 'GetTotalStats') return async () => ({ total_km: 0, total_time: 0 });
                     if (prop === 'GetActivities') return async () => [];
                     if (prop === 'GetMonthlyActivities') return async () => [];
                     if (prop === 'GetPowerCurve') return async () => [];
                     if (prop === 'GetCareerDashboard') return async () => ({ pmc: [], mmp: [] });
-                    
+
                     return async () => { console.log("Mocked Go App call:", prop); return null; };
                 }
             })
@@ -45,7 +45,7 @@ if (typeof window.go === 'undefined') {
 // MOBILE PHYSICS POLYFILL
 // =======================
 if (typeof window.WasmCalculateSpeed === 'undefined') {
-    window.WasmCalculateSpeed = function(watts, gradePct, riderWeight, bikeWeight) {
+    window.WasmCalculateSpeed = function (watts, gradePct, riderWeight, bikeWeight) {
         if (watts <= 0) {
             if (gradePct < -2.0) return Math.sqrt(-gradePct / 100 * 9.81 * 2);
             return 0;
@@ -57,27 +57,27 @@ if (typeof window.WasmCalculateSpeed === 'undefined') {
         const cdA = 0.32; // Aerodynamic Coefficient
         const rho = 1.225; // Air Density
         const gradeDecimal = gradePct / 100.0;
-        
+
         // Transmission losses (3%)
         const powerToWheel = watts * 0.97;
 
         let v = 5.0; // Initial starting point (m/s)
-        
+
         // Newton-Raphson method for finding the exact speed.
         for (let i = 0; i < 10; i++) {
             const F_grav = g * m * Math.sin(Math.atan(gradeDecimal));
             const F_roll = g * m * Math.cos(Math.atan(gradeDecimal)) * crr;
             const F_aero = 0.5 * cdA * rho * v * v;
-            
+
             const P_total = (F_grav + F_roll + F_aero) * v;
             const P_diff = P_total - powerToWheel;
-            
+
             const dP_dv = F_grav + F_roll + 1.5 * cdA * rho * v * v;
-            
+
             v = v - (P_diff / dP_dv);
             if (v < 0) return 0;
         }
-        
+
         return v;
     };
 }
@@ -85,7 +85,7 @@ if (typeof window.WasmCalculateSpeed === 'undefined') {
 if (typeof window.runtime === 'undefined') {
     window.runtime = {
         EventsOn: (event, cb) => console.log("Mocked Wails Event:", event),
-        EventsEmit: () => {}
+        EventsEmit: () => { }
     };
 }
 // ==========================
@@ -115,11 +115,11 @@ if (Capacitor.isNativePlatform()) {
     mobileBLE = new CapacitorBluetoothService();
     window.mobileBLE = mobileBLE;
     console.log("Native Mobile Mode Detected (Capacitor)");
-    
+
     document.getElementById('btnScanTrainer').classList.add('hidden');
     document.getElementById('trainerList').classList.add('hidden');
     document.getElementById('btnConnTrainer').classList.remove('hidden');
-    
+
     document.getElementById('btnScanHR').classList.add('hidden');
     document.getElementById('hrList').classList.add('hidden');
     document.getElementById('btnConnHR').classList.remove('hidden');
@@ -132,10 +132,10 @@ window.closeWorkout = async () => {
         if (Capacitor.isNativePlatform()) {
             console.log("Mobile: Returned to SIM mode.");
         } else if (window.go && window.go.main && window.go.main.App) {
-            try { 
-                await window.go.main.App.SetTrainerMode('SIM'); 
-            } catch (e) { 
-                console.error("Error returning to SIM mode:", e); 
+            try {
+                await window.go.main.App.SetTrainerMode('SIM');
+            } catch (e) {
+                console.error("Error returning to SIM mode:", e);
             }
         }
     }
@@ -163,7 +163,7 @@ document.getElementById('selectTrainerMode').addEventListener('change', async (e
 
 document.getElementById('btnSetPower').addEventListener('click', async () => {
     const watts = parseFloat(document.getElementById('inputTargetPower').value);
-    
+
     if (Capacitor.isNativePlatform() && window.mobileBLE) {
         window.mobileBLE.sendTargetPower(watts);
     } else if (!Capacitor.isNativePlatform() && window.go && window.go.main && window.go.main.App) {
@@ -174,21 +174,33 @@ document.getElementById('btnSetPower').addEventListener('click', async () => {
 document.getElementById('btnCloseSettings').addEventListener('click', () => ui.toggleSettings(false));
 document.getElementById('btnOpenSettings').addEventListener('click', () => ui.toggleSettings(true));
 
+// --- Dashboard Toggle Event ---
+document.getElementById('btnToggleView').addEventListener('click', () => {
+    window.ui.toggleDashboardMode();
+});
 
 // ==================
 // DEVICE CONNECTIONS
 // ==================
 
+const svgIcons = {
+    scan: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`,
+    bt: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6.5 6.5 17.5 17.5 12 23 12 1 17.5 6.5 6.5 17.5"></polyline></svg>`,
+    virtual: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="2" y1="20" x2="22" y2="20"></line></svg>`,
+    disconnect: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
+    wait: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 22h14"></path><path d="M5 2h14"></path><path d="M14 22V18.13a4 4 0 0 0-1.17-2.83L12 14.4l-1.83.9A4 4 0 0 0 9 18.13V22"></path><path d="M14 2v3.87a4 4 0 0 1-1.17 2.83L12 9.6l-1.83-.9A4 4 0 0 1 9 5.87V2"></path></svg>`
+};
+
 // 1. SCAN TRAINERS (Desktop only)
 document.getElementById('btnScanTrainer').addEventListener('click', async () => {
-    if (Capacitor.isNativePlatform()) return; 
-    
+    if (Capacitor.isNativePlatform()) return;
+
     const btnScan = document.getElementById('btnScanTrainer');
     const btnConn = document.getElementById('btnConnTrainer');
     const list = document.getElementById('trainerList');
     const status = document.getElementById('statusTrainer');
 
-    btnScan.innerText = "⏳";
+    btnScan.innerHTML = svgIcons.wait;
     btnScan.disabled = true;
     status.innerText = "Scanning...";
 
@@ -208,10 +220,10 @@ document.getElementById('btnScanTrainer').addEventListener('click', async () => 
             status.innerText = "Select a device";
         } else {
             status.innerText = "No devices found";
-            btnScan.innerText = "🔍"; btnScan.disabled = false;
+            btnScan.innerHTML = svgIcons.scan; btnScan.disabled = false;
         }
     } catch (err) {
-        status.innerText = "Scan error"; btnScan.innerText = "🔍"; btnScan.disabled = false;
+        status.innerText = "Scan error"; btnScan.innerHTML = svgIcons.scan; btnScan.disabled = false;
     }
 });
 
@@ -229,22 +241,22 @@ document.getElementById('btnConnTrainer').addEventListener('click', async () => 
             await mobileBLE.disconnectTrainer();
             status.innerText = "Disconnected";
             status.style.color = "";
-            btnReal.innerText = "🔗";
+            btnReal.innerHTML = svgIcons.bt;
             return;
         }
 
-        btnReal.innerText = "⏳";
+        btnReal.innerHTML = svgIcons.wait;
         const success = await mobileBLE.connectTrainer(
-            (msg) => { 
+            (msg) => {
                 status.innerText = msg;
                 if (msg === "Trainer Connected") status.style.color = "var(--argus-safe)";
             },
-            (data) => { 
-                ui.updateTelemetry(data, window.totalRouteDistance); 
+            (data) => {
+                ui.updateTelemetry(data, window.totalRouteDistance);
                 if (window.mapController) window.mapController.updateCyclistPosition(data.lat, data.lon, data.speed, data);
             }
         );
-        btnReal.innerText = success ? "❌" : "🔗";
+        btnReal.innerHTML = success ? svgIcons.disconnect : svgIcons.bt;
         return;
     }
 
@@ -253,9 +265,9 @@ document.getElementById('btnConnTrainer').addEventListener('click', async () => 
         if (status.innerText === "Trainer Connected") {
             await window.go.main.App.DisconnectTrainer();
             status.innerText = "Disconnected"; status.style.color = "";
-            btnReal.innerText = "🔗"; btnReal.classList.add('hidden');
+            btnReal.innerHTML = svgIcons.bt; btnReal.classList.add('hidden');
             list.classList.add('hidden'); list.disabled = false;
-            btnScan.classList.remove('hidden'); btnScan.innerText = "🔍"; btnScan.disabled = false;
+            btnScan.classList.remove('hidden'); btnScan.innerHTML = svgIcons.scan; btnScan.disabled = false;
             btnVirtual.disabled = false;
             return;
         }
@@ -263,15 +275,15 @@ document.getElementById('btnConnTrainer').addEventListener('click', async () => 
         const selectedMac = list.value;
         if (!selectedMac) { alert("Please select a trainer from the list."); return; }
 
-        btnReal.innerText = "⏳"; btnReal.disabled = true; btnVirtual.disabled = true; list.disabled = true;
+        btnReal.innerHTML = svgIcons.wait; btnReal.disabled = true; btnVirtual.disabled = true; list.disabled = true;
 
         try {
             const result = await window.go.main.App.ConnectTrainer(selectedMac);
             status.innerText = result; status.style.color = "var(--argus-safe)";
-            btnReal.innerText = "❌"; btnReal.disabled = false;
+            btnReal.innerHTML = svgIcons.disconnect; btnReal.disabled = false;
         } catch (err) {
             status.innerText = "Error connecting"; status.style.color = "var(--argus-alert)";
-            btnReal.innerText = "🔗"; btnReal.disabled = false; btnVirtual.disabled = false; list.disabled = false;
+            btnReal.innerHTML = svgIcons.bt; btnReal.disabled = false; btnVirtual.disabled = false; list.disabled = false;
         }
     }
 });
@@ -282,7 +294,7 @@ document.getElementById('btnConnTrainer').addEventListener('click', async () => 
 
 document.getElementById('btnConnVirtual').addEventListener('click', async () => {
     if (Capacitor.isNativePlatform()) { alert("Virtual Simulator not available on mobile yet."); return; }
-    
+
     const btnVirtual = document.getElementById('btnConnVirtual');
     const btnReal = document.getElementById('btnConnTrainer');
     const btnScan = document.getElementById('btnScanTrainer');
@@ -292,34 +304,35 @@ document.getElementById('btnConnVirtual').addEventListener('click', async () => 
     if (status.innerText === "Simulator Active") {
         await window.go.main.App.DisconnectTrainer();
         status.innerText = "Disconnected"; status.style.color = "";
-        btnVirtual.innerText = "💻"; btnScan.disabled = false;
+        btnVirtual.innerHTML = svgIcons.virtual; btnScan.disabled = false;
         return;
     }
 
-    btnVirtual.innerText = "⏳"; btnVirtual.disabled = true; btnScan.disabled = true;
+    btnVirtual.innerHTML = svgIcons.wait; btnVirtual.disabled = true; btnScan.disabled = true;
     if (!btnReal.classList.contains('hidden')) btnReal.disabled = true;
 
     try {
         const result = await window.go.main.App.ConnectVirtualTrainer();
         status.innerText = result; status.style.color = "#00ADD8";
-        btnVirtual.innerText = "❌"; btnVirtual.disabled = false;
+        // Usa um X vermelho elegante quando conectado (para poder desconectar)
+        btnVirtual.innerHTML = svgIcons.disconnect; btnVirtual.disabled = false;
         list.classList.add('hidden'); btnReal.classList.add('hidden'); btnScan.classList.remove('hidden');
     } catch (err) {
         status.innerText = "Error: " + err; status.style.color = "var(--argus-alert)";
-        btnVirtual.innerText = "💻"; btnVirtual.disabled = false; btnScan.disabled = false;
+        btnVirtual.innerHTML = svgIcons.virtual; btnVirtual.disabled = false; btnScan.disabled = false;
     }
 });
 
 // 1. SCAN HR (Desktop only)
 document.getElementById('btnScanHR').addEventListener('click', async () => {
     if (Capacitor.isNativePlatform()) return;
-    
+
     const btnScan = document.getElementById('btnScanHR');
     const btnConn = document.getElementById('btnConnHR');
     const list = document.getElementById('hrList');
     const status = document.getElementById('statusHR');
 
-    btnScan.innerText = "⏳"; btnScan.disabled = true; status.innerText = "Scanning...";
+    btnScan.innerHTML = svgIcons.wait; btnScan.disabled = true; status.innerText = "Scanning...";
 
     try {
         const devices = await window.go.main.App.ScanHeartRate();
@@ -333,9 +346,9 @@ document.getElementById('btnScanHR').addEventListener('click', async () => {
             list.classList.remove('hidden'); btnConn.classList.remove('hidden'); btnScan.classList.add('hidden');
             status.innerText = "Select a device";
         } else {
-            status.innerText = "No devices found"; btnScan.innerText = "🔍"; btnScan.disabled = false;
+            status.innerText = "No devices found"; btnScan.innerHTML = svgIcons.scan; btnScan.disabled = false;
         }
-    } catch (err) { status.innerText = "Scan error"; btnScan.innerText = "🔍"; btnScan.disabled = false; }
+    } catch (err) { status.innerText = "Scan error"; btnScan.innerHTML = svgIcons.scan; btnScan.disabled = false; }
 });
 
 // 2. CONNECT HR (Dual Mode)
@@ -349,16 +362,16 @@ document.getElementById('btnConnHR').addEventListener('click', async () => {
     if (Capacitor.isNativePlatform()) {
         if (status.innerText === "HR Connected") {
             await mobileBLE.disconnectHeartRate();
-            status.innerText = "Disconnected"; status.style.color = ""; btnReal.innerText = "🔗";
+            status.innerText = "Disconnected"; status.style.color = ""; btnReal.innerHTML = svgIcons.bt;
             return;
         }
 
-        btnReal.innerText = "⏳";
-        const success = await mobileBLE.connectHeartRate((msg) => { 
+        btnReal.innerHTML = svgIcons.wait;
+        const success = await mobileBLE.connectHeartRate((msg) => {
             status.innerText = msg;
             if (msg === "HR Connected") status.style.color = "var(--argus-safe)";
         });
-        btnReal.innerText = success ? "❌" : "🔗";
+        btnReal.innerHTML = success ? svgIcons.disconnect : svgIcons.bt;
         return;
     }
 
@@ -367,24 +380,24 @@ document.getElementById('btnConnHR').addEventListener('click', async () => {
         if (status.innerText === "HR Monitor Connected" || status.innerText === "Connected") {
             await window.go.main.App.DisconnectHeartRate();
             status.innerText = "Disconnected"; status.style.color = "";
-            btnReal.innerText = "🔗"; btnReal.classList.add('hidden');
+            btnReal.innerHTML = svgIcons.bt; btnReal.classList.add('hidden');
             list.classList.add('hidden'); list.disabled = false;
-            btnScan.classList.remove('hidden'); btnScan.innerText = "🔍"; btnScan.disabled = false;
+            btnScan.classList.remove('hidden'); btnScan.innerHTML = svgIcons.scan; btnScan.disabled = false;
             return;
         }
 
         const selectedMac = list.value;
         if (!selectedMac) { alert("Please select a HR monitor from the list."); return; }
 
-        btnReal.innerText = "⏳"; btnReal.disabled = true; list.disabled = true;
+        btnReal.innerHTML = svgIcons.wait; btnReal.disabled = true; list.disabled = true;
 
         try {
             const result = await window.go.main.App.ConnectHeartRate(selectedMac);
             status.innerText = result; status.style.color = "var(--argus-safe)";
-            btnReal.innerText = "❌"; btnReal.disabled = false;
+            btnReal.innerHTML = svgIcons.disconnect; btnReal.disabled = false;
         } catch (err) {
             status.innerText = "Error"; status.style.color = "var(--argus-alert)";
-            btnReal.innerText = "🔗"; btnReal.disabled = false; list.disabled = false;
+            btnReal.innerHTML = svgIcons.bt; btnReal.disabled = false; list.disabled = false;
         }
     }
 });
@@ -448,7 +461,7 @@ document.getElementById('btnImport').addEventListener('click', async () => {
 
                 mapCtrl.renderRoute({ type: 'FeatureCollection', features: features });
                 mapCtrl.setInitialPosition(routePoints[0].lat, routePoints[0].lon);
-                
+
                 const elevations = await window.go.main.App.GetElevationProfile();
                 chart.setData(elevations);
             }
@@ -461,17 +474,17 @@ function parseGPXForMobile(gpxText, filename) {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(gpxText, "text/xml");
     const trkpts = xmlDoc.getElementsByTagName("trkpt");
-    
+
     if (trkpts.length === 0) { alert("No route points found in GPX"); return; }
 
     const points = [];
     let totalDist = 0;
-    
+
     const calcDist = (lat1, lon1, lat2, lon2) => {
-        const R = 6371e3; const p1 = lat1 * Math.PI/180; const p2 = lat2 * Math.PI/180;
-        const dp = (lat2-lat1) * Math.PI/180; const dl = (lon2-lon1) * Math.PI/180;
-        const a = Math.sin(dp/2) * Math.sin(dp/2) + Math.cos(p1) * Math.cos(p2) * Math.sin(dl/2) * Math.sin(dl/2);
-        return R * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a)));
+        const R = 6371e3; const p1 = lat1 * Math.PI / 180; const p2 = lat2 * Math.PI / 180;
+        const dp = (lat2 - lat1) * Math.PI / 180; const dl = (lon2 - lon1) * Math.PI / 180;
+        const a = Math.sin(dp / 2) * Math.sin(dp / 2) + Math.cos(p1) * Math.cos(p2) * Math.sin(dl / 2) * Math.sin(dl / 2);
+        return R * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
     };
 
     for (let i = 0; i < trkpts.length; i++) {
@@ -479,27 +492,27 @@ function parseGPXForMobile(gpxText, filename) {
         const lon = parseFloat(trkpts[i].getAttribute("lon"));
         const eleNode = trkpts[i].getElementsByTagName("ele")[0];
         const ele = eleNode ? parseFloat(eleNode.textContent) : 0;
-        
-        if (i > 0) totalDist += calcDist(points[i-1].lat, points[i-1].lon, lat, lon);
+
+        if (i > 0) totalDist += calcDist(points[i - 1].lat, points[i - 1].lon, lat, lon);
         points.push({ lat, lon, ele, distance: totalDist, grade: 0 });
     }
 
     for (let i = 1; i < points.length; i++) {
-        const p1 = points[i-1]; const p2 = points[i];
+        const p1 = points[i - 1]; const p2 = points[i];
         const dDist = p2.distance - p1.distance;
         p2.grade = dDist > 0 ? ((p2.ele - p1.ele) / dDist) * 100 : p1.grade;
     }
-    
+
     const smoothedPoints = points.map((p, i, arr) => {
-        let start = Math.max(0, i-2), end = Math.min(arr.length-1, i+2), sumGrade = 0;
-        for(let j=start; j<=end; j++) sumGrade += arr[j].grade;
+        let start = Math.max(0, i - 2), end = Math.min(arr.length - 1, i + 2), sumGrade = 0;
+        for (let j = start; j <= end; j++) sumGrade += arr[j].grade;
         return { ...p, grade: sumGrade / (end - start + 1) };
     });
 
     window.mobileRoutePoints = smoothedPoints;
     window.totalRouteDistance = totalDist;
 
-    window.WasmGetRoutePoint = function(dist) {
+    window.WasmGetRoutePoint = function (dist) {
         const pts = window.mobileRoutePoints;
         if (!pts || pts.length === 0) return null;
         const safeDist = dist % window.totalRouteDistance;
@@ -516,10 +529,10 @@ function parseGPXForMobile(gpxText, filename) {
     for (let i = 0; i < smoothedPoints.length - 1; i++) {
         features.push({
             type: 'Feature', properties: { grade: smoothedPoints[i].grade },
-            geometry: { type: 'LineString', coordinates: [[smoothedPoints[i].lon, smoothedPoints[i].lat], [smoothedPoints[i+1].lon, smoothedPoints[i+1].lat]] }
+            geometry: { type: 'LineString', coordinates: [[smoothedPoints[i].lon, smoothedPoints[i].lat], [smoothedPoints[i + 1].lon, smoothedPoints[i + 1].lat]] }
         });
     }
-    
+
     window.mapController.renderRoute({ type: 'FeatureCollection', features: features });
     window.mapController.setInitialPosition(smoothedPoints[0].lat, smoothedPoints[0].lon);
     window.chart.setData(smoothedPoints.map(p => p.ele));
@@ -561,12 +574,12 @@ document.getElementById('btnLoadWorkout').addEventListener('click', async () => 
 function parseZWOForMobile(xmlString) {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(xmlString, "text/xml");
-    
+
     const workoutObj = { Segments: [], TotalDuration: 0 };
     const workoutNodes = xmlDoc.getElementsByTagName("workout");
-    
+
     if (workoutNodes.length === 0) { alert("Invalid ZWO file."); return; }
-    
+
     const elements = workoutNodes[0].children;
     let idx = 0;
 
@@ -574,7 +587,7 @@ function parseZWOForMobile(xmlString) {
         const el = elements[i];
         const type = el.tagName;
         const dur = parseInt(el.getAttribute("Duration")) || 0;
-        
+
         if (type === "SteadyState" || type === "FreeRide") {
             const pwr = parseFloat(el.getAttribute("Power")) || 0;
             workoutObj.Segments.push({ Index: idx++, Type: "STEADY", DurationSeconds: dur, StartFactor: pwr, EndFactor: pwr });
@@ -611,7 +624,7 @@ function parseZWOForMobile(xmlString) {
 async function finishWorkout() {
     isFinishTriggered = true;
     window.isRecording = false;
-    
+
     // --- MOBILE MODE (Capacitor) ---
     if (Capacitor.isNativePlatform()) {
         ui.setRecordingState('IDLE');
@@ -701,14 +714,30 @@ function openTab(tabId, event) {
 window.openTab = openTab;
 
 if (window.runtime && !Capacitor.isNativePlatform()) {
+
     window.runtime.EventsOn("ble_connection_status", (data) => {
-        if (data.stage === "READY") mapCtrl.followCyclist = true;
+        if (data.stage === "READY") {
+            mapCtrl.followCyclist = true;
+        }
     });
 
     window.runtime.EventsOn("status_change", (status) => {
-        if (status === "RECORDING") { ui.setRecordingState('RECORDING'); window.isRecording = true; }
-        else if (status === "PAUSED") { ui.setRecordingState('PAUSED'); window.isRecording = true; }
-        else { ui.setRecordingState('IDLE'); window.isRecording = false; }
+        if (status === "RECORDING") {
+            ui.setRecordingState('RECORDING');
+            window.isRecording = true;
+        }
+        else if (status === "PAUSED") {
+            ui.setRecordingState('PAUSED');
+            window.isRecording = true;
+        }
+        else {
+            ui.setRecordingState('IDLE');
+            window.isRecording = false;
+
+            if (window.ui) {
+                window.ui.resetDashboardData();
+            }
+        }
     });
 
     window.runtime.EventsOn("telemetry_update", (data) => {

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -74,11 +74,27 @@ export class UIManager {
             // History & statistics
             historyContainer: document.getElementById('historyContainer'),
             statTotalDist: document.getElementById('statTotalDist'),
-            statTotalActivities: document.getElementById('statTotalActivities')
+            statTotalActivities: document.getElementById('statTotalActivities'),
+
+            // --- Dashboard Elements ---
+            btnToggleView: document.getElementById('btnToggleView'),
+            dashboardView: document.getElementById('dashboard-view'),
+            mapContainer: document.getElementById('map-container'),
+            hudSidebar: document.querySelector('.hud-sidebar'),
+            dashPower: document.getElementById('dash-power'),
+            dashWkg: document.getElementById('dash-wkg'),
+            dashHr: document.getElementById('dash-hr'),
+            dashRpm: document.getElementById('dash-rpm'),
+            dashSpeed: document.getElementById('dash-speed'),
+            dashDist: document.getElementById('dash-dist'),
+            dashTime: document.getElementById('dash-time'),
         };
 
         // --- GLOBAL ACCESS ---
         window.ui = this;
+
+        // --- VIEW STATE ---
+        this.isDashboardMode = false; // Tracks if map is hidden
 
         // --- TIMER STATE ---
         this.timerInterval = null;
@@ -99,6 +115,133 @@ export class UIManager {
         this.level = 1;
         this.xp = 0;
         this.nextLevelXp = 500;
+
+        // --- Live Chart Data Arrays ---
+        this.liveChartInstance = null;
+        this.liveTimeData = [];
+        this.livePowerData = [];
+        this.liveHrData = [];
+        this.liveCadenceData = [];
+
+        const workoutPanel = document.getElementById('workout-panel');
+        if (workoutPanel && this.els.dashboardView) {
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.attributeName === 'class') {
+                        const isOpen = !workoutPanel.classList.contains('hidden');
+                        this.els.dashboardView.style.right = isOpen ? '340px' : '0px';
+                        if (this.liveChartInstance) {
+                            setTimeout(() => this.liveChartInstance.resize(), 300);
+                        }
+                    }
+                });
+            });
+            observer.observe(workoutPanel, { attributes: true });
+        }
+    }
+
+    // ===========
+    // VIEW TOGGLE
+    // ===========
+
+    /**
+     * Toggles the application between Map View and Offline Dashboard View
+     */
+    toggleDashboardMode() {
+        this.isDashboardMode = !this.isDashboardMode;
+
+        if (this.isDashboardMode) {
+            this.els.dashboardView.classList.remove('hidden');
+            this.els.mapContainer.style.display = 'none';
+            this.els.hudSidebar.style.display = 'none';
+            
+            // --- NEW: Initialize and resize chart ---
+            this.initLiveChart();
+            if (this.liveChartInstance) {
+                setTimeout(() => this.liveChartInstance.resize(), 100);
+            }
+        } else {
+            this.els.dashboardView.classList.add('hidden');
+            this.els.mapContainer.style.display = 'block';
+            this.els.hudSidebar.style.display = 'flex';
+        }
+    }
+
+    // ====================
+    // LIVE DASHBOARD CHART
+    // ====================
+
+    initLiveChart() {
+        const chartDom = document.getElementById('liveDashboardChart');
+        if (!chartDom) return;
+
+        // Initialize ECharts instance if it doesn't exist
+        if (!this.liveChartInstance) {
+            this.liveChartInstance = echarts.init(chartDom, 'dark', { background: 'transparent' });
+        }
+
+        const option = {
+            animation: false,
+            tooltip: { trigger: 'axis' },
+            legend: {
+                data: ['Power (w)', 'Heart Rate (bpm)', 'Cadence (rpm)'],
+                textStyle: { color: '#ccc' },
+                top: 0
+            },
+            grid: { left: '3%', right: '3%', bottom: '5%', top: 40, containLabel: true },
+            xAxis: {
+                type: 'category',
+                boundaryGap: false,
+                data: this.liveTimeData,
+                axisLabel: { color: '#888' },
+                splitLine: { show: false }
+            },
+            yAxis: [
+                {
+                    type: 'value',
+                    name: 'Watts',
+                    position: 'left',
+                    splitLine: { lineStyle: { color: '#333', type: 'dashed' } }
+                },
+                {
+                    type: 'value',
+                    name: 'BPM / RPM',
+                    position: 'right',
+                    splitLine: { show: false }
+                }
+            ],
+            series: [
+                {
+                    name: 'Power (w)',
+                    type: 'line',
+                    yAxisIndex: 0,
+                    symbol: 'none',
+                    itemStyle: { color: '#f1c40f' },
+                    areaStyle: { color: 'rgba(241, 196, 15, 0.1)' },
+                    data: this.livePowerData
+                },
+                {
+                    name: 'Heart Rate (bpm)',
+                    type: 'line',
+                    yAxisIndex: 1,
+                    symbol: 'none',
+                    itemStyle: { color: '#e74c3c' },
+                    smooth: true,
+                    data: this.liveHrData
+                },
+                {
+                    name: 'Cadence (rpm)',
+                    type: 'line',
+                    yAxisIndex: 1,
+                    symbol: 'none',
+                    itemStyle: { color: '#3498db' },
+                    smooth: true,
+                    data: this.liveCadenceData
+                }
+            ]
+        };
+
+        this.liveChartInstance.setOption(option);
     }
 
     // =========================
@@ -183,6 +326,49 @@ export class UIManager {
             const pct = Math.min((lapDist / totalRouteDistance) * 100, 100);
             this.els.cursor.style.left = pct + '%';
         }
+
+        // --- NEW: Update Dashboard Mode Data & Chart ---
+        if (this.isDashboardMode) {
+            this.els.dashPower.innerHTML = `${data.power}<span class="dash-unit">w</span>`;
+            this.els.dashWkg.innerText = `${wkgVal} w/kg`;
+            this.els.dashHr.innerHTML = `${data.heart_rate}<span class="dash-unit">bpm</span>`;
+            this.els.dashRpm.innerHTML = `${data.cadence}<span class="dash-unit">rpm</span>`;
+            this.els.dashSpeed.innerHTML = `${speedObj.val}<span class="dash-unit">${speedObj.unit}</span>`;
+            this.els.dashDist.innerHTML = `${distObj.val}<span class="dash-unit">${distObj.unit}</span>`;
+            
+            // Keep chart data array length to max 60 seconds (or points) so it scrolls horizontally
+            // Mantém o tamanho do array no máximo em 60 pontos
+            if (this.livePowerData.length > 60) {
+                this.livePowerData.shift();
+                this.liveHrData.shift();
+                this.liveCadenceData.shift(); // <-- ADICIONE AQUI
+                this.liveTimeData.shift();
+            }
+
+            // Calcula o tempo real da sessão
+            const h = Math.floor((this.secondsElapsed || 0) / 3600).toString().padStart(2, '0');
+            const m = Math.floor(((this.secondsElapsed || 0) % 3600) / 60).toString().padStart(2, '0');
+            const s = ((this.secondsElapsed || 0) % 60).toString().padStart(2, '0');
+            const timeStr = `${h}:${m}:${s}`;
+            
+            // Empurra os novos pontos
+            this.liveTimeData.push(timeStr);
+            this.livePowerData.push(data.power);
+            this.liveHrData.push(data.heart_rate);
+            this.liveCadenceData.push(data.cadence); // <-- ADICIONE AQUI
+
+            // Diz ao ECharts para redesenhar as 3 linhas
+            if (this.liveChartInstance) {
+                this.liveChartInstance.setOption({
+                    xAxis: { data: this.liveTimeData },
+                    series: [ 
+                        { data: this.livePowerData }, 
+                        { data: this.liveHrData },
+                        { data: this.liveCadenceData } // <-- ADICIONE AQUI
+                    ]
+                });
+            }
+        }
     }
 
     /**
@@ -192,9 +378,48 @@ export class UIManager {
         this.els.filename.innerText = "| " + name;
     }
 
-    // =================
+    // ===============
+    // RESET TELEMETRY
+    // ===============
+
+    resetDashboardData() {
+        this.secondsElapsed = 0;
+        this.updateTimerDisplay();
+
+        if (this.els.dashPower) this.els.dashPower.innerHTML = `0<span class="dash-unit">w</span>`;
+        if (this.els.dashWkg) this.els.dashWkg.innerText = `0.0 w/kg`;
+        if (this.els.dashHr) this.els.dashHr.innerHTML = `--<span class="dash-unit">bpm</span>`;
+        if (this.els.dashRpm) this.els.dashRpm.innerHTML = `0<span class="dash-unit">rpm</span>`;
+        if (this.els.dashSpeed) this.els.dashSpeed.innerHTML = `0.0<span class="dash-unit">km/h</span>`;
+        if (this.els.dashDist) this.els.dashDist.innerHTML = `0.00<span class="dash-unit">km</span>`;
+
+        if (this.els.watts) this.els.watts.innerHTML = `0<span class="data-unit">w</span>`;
+        if (this.els.wkg) this.els.wkg.innerHTML = `0.0<span class="data-unit">w/kg</span>`;
+        if (this.els.hr) this.els.hr.innerHTML = `--<span class="data-unit">❤</span>`;
+        if (this.els.rpm) this.els.rpm.innerHTML = `0<span class="data-unit">rpm</span>`;
+        if (this.els.speed) this.els.speed.innerHTML = `0.0<span class="data-unit">km/h</span>`;
+        if (this.els.dist) this.els.dist.innerHTML = `0.0<span class="data-unit">km</span>`;
+        
+        this.liveTimeData = [];
+        this.livePowerData = [];
+        this.liveHrData = [];
+        this.liveCadenceData = [];
+        
+        if (this.liveChartInstance) {
+            this.liveChartInstance.setOption({
+                xAxis: { data: this.liveTimeData },
+                series: [ 
+                    { data: this.livePowerData }, 
+                    { data: this.liveHrData },
+                    { data: this.liveCadenceData } 
+                ]
+            });
+        }
+    }
+
+    // =============
     // ROUTE PREVIEW
-    // =================
+    // =============
 
     /**
      * Display route statistics before the ride starts.
@@ -226,12 +451,6 @@ export class UIManager {
         // Set the Remaining Distance to the Total Distance
         const remObj = this.formatDist(totalDistance);
         this.els.distRem.innerHTML = `${remObj.val}<span class="data-unit">${remObj.unit}</span>`;
-
-        // If you have a specific UI element for Elevation, update it here.
-        // For example, if you added: this.els.elevation = document.getElementById('total-elevation');
-        // if (this.els.elevation) {
-        //     this.els.elevation.innerHTML = `${totalElevation.toFixed(0)}<span class="data-unit">m</span>`;
-        // }
 
         // Reset Cursor
         if (this.els.cursor) {
@@ -284,11 +503,18 @@ export class UIManager {
     /**
      * Update HH:MM:SS timer display.
      */
-    updateTimerDisplay() {
+ updateTimerDisplay() {
         const h = Math.floor(this.secondsElapsed / 3600).toString().padStart(2, '0');
         const m = Math.floor((this.secondsElapsed % 3600) / 60).toString().padStart(2, '0');
         const s = (this.secondsElapsed % 60).toString().padStart(2, '0');
-        this.els.time.innerText = `${h}:${m}:${s}`;
+        const timeStr = `${h}:${m}:${s}`;
+        
+        this.els.time.innerText = timeStr;
+        
+        // --- Update Dashboard Time ---
+        if (this.els.dashTime) {
+            this.els.dashTime.innerText = timeStr;
+        }
     }
 
     // ===================
@@ -1090,4 +1316,5 @@ export class UIManager {
 
         this.careerMmpChartInstance.setOption(option);
     }
+
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1278,6 +1278,7 @@ html[data-theme="day"] .history-item {
 
 /* Mirrored Positioning Relative to the Left Sidebar */
 .hud-sidebar.right-panel {
+    margin-left: auto;
     right: 20px;
     left: auto;
     display: flex;
@@ -1986,4 +1987,106 @@ TACTICAL BLUE
         font-size: 1.2rem;
         margin-top: 20px;
     }
+}
+/* ======================================
+   OFFLINE DASHBOARD MODE (STUDIO LAYOUT)
+   ====================================== */
+.dashboard-container {
+    position: absolute;
+    top: 60px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--bg-main);
+    z-index: 5;
+    display: flex;
+    justify-content: center;
+    padding: 20px;
+    overflow: hidden;
+    transition: right 0.3s ease-in-out;
+}
+
+.dashboard-container.hidden {
+    display: none !important;
+}
+
+.dash-layout {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 1400px;
+    height: 100%;
+    gap: 20px;
+}
+
+/* --- TOP ROW (METRICS) --- */
+.dash-metrics-row {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 1fr;
+    gap: 15px;
+    flex-shrink: 0;
+}
+
+.dash-card {
+    background: rgba(30, 41, 59, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    padding: 20px 15px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+}
+
+.dash-label {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 1.5px;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+}
+
+.dash-value {
+    font-size: 2.5rem;
+    font-weight: 900;
+    color: var(--text-main);
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+    line-height: 1;
+}
+
+.dash-unit {
+    font-size: 1rem;
+    color: var(--text-muted);
+    margin-left: 5px;
+}
+
+.dash-sub {
+    margin-top: 5px;
+    font-size: 1rem;
+    font-weight: bold;
+}
+
+/* --- BOTTOM ROW (LIVE CHART) --- */
+.dash-chart-section {
+    flex: 1;
+    background: rgba(15, 23, 42, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.dash-chart-header {
+    padding: 15px 20px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.dash-chart-body {
+    flex: 1;
+    position: relative;
+    padding: 10px;
 }


### PR DESCRIPTION
## Description
This PR introduces the "Offline Dashboard Mode", allowing users to train with a data-centric, full-screen UI without relying on the MapLibre engine or internet connectivity. It heavily optimizes the user experience for offline or indoor studio scenarios.

## Changes Made
* **UI/UX:** Added a toggle in the header to switch between Map View and Dashboard View.
* **Layout:** Implemented a Flexbox "Studio Layout" featuring 6 large telemetry cards (Power, HR, Cadence, Speed, Distance, Time).
* **Live Chart:** Integrated an ECharts instance that plots Power (Yellow), Heart Rate (Red), and Cadence (Green) dynamically over a 60-second rolling window.
* **Responsive Design:** Added a `MutationObserver` that gracefully pads the dashboard chart to the left when the right-side Workout Panel is opened.
* **State Management:** Created `resetDashboardData()` to wipe out the chart and metrics when the backend emits an `IDLE` state.
* **Backend Stability:** Updated `app.go` game loop to filter out empty BLE cadence packets, ensuring chart lines remain smooth and do not drop to zero unless power is also zero.
* **Iconography:** Replaced all legacy text-based emojis (🔍, 🔗, ⏳) with modern SVG icons for a cleaner UI.

## Closes
Closes #85

## Testing
- [x] Toggle between Map and Dashboard works seamlessly.
- [x] Live chart draws lines correctly and scrolls horizontally.
- [x] Discarding a session clears all dashboard numbers and the chart.
- [x] Opening a workout resizes the dashboard without overlapping.
- [x] Cadence line remains stable during pedaling.