### PR TITLE
Fix: Black map rendering on ZWO file import (#71)

### DIFF
--- a/frontend/src/modules/WorkoutController.js
+++ b/frontend/src/modules/WorkoutController.js
@@ -86,6 +86,14 @@ export class WorkoutController {
         this.activeWorkout = workout;
         this.panel.classList.remove('hidden');
 
+        setTimeout(() => {
+            if (window.mapController && window.mapController.map) {
+                window.mapController.map.resize();
+            } else {
+                window.dispatchEvent(new Event('resize'));
+            }
+        }, 50);
+
         this.renderList();
 
         requestAnimationFrame(() => this.renderGraph(0));


### PR DESCRIPTION
## Description
This PR resolves Issue #71, where the map would render as a black screen immediately after loading a `.zwo` workout file and displaying the workout panel.

## Root Cause
When the workout panel becomes visible (`this.panel.classList.remove('hidden')`), it shifts the screen layout and resizes the map's `div`. The MapLibre library loses the reference to its new container dimensions before the browser finishes repainting the DOM, resulting in a black canvas until a manual window resize occurs.

## Solution
Implemented a `setTimeout` of 50ms in `WorkoutController.js` (`loadWorkout` method) right after the UI changes. This slight delay allows the DOM to finish rendering the workout panel before explicitly forcing `map.resize()` (or dispatching a `resize` event). This recalculates the canvas dimensions perfectly, eliminating the black screen.

## Related Issues
Closes #71

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas