### PR TITLE
feat: allow repeating or loading new workouts after completion (#109)

### DIFF
--- a/app.go
+++ b/app.go
@@ -21,13 +21,13 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	stdruntime "runtime"
 	"strings"
 	"time"
-	"net/http"
 
 	"argus-cyclist/internal/domain"
 	"argus-cyclist/internal/service/ble"
@@ -35,9 +35,9 @@ import (
 	"argus-cyclist/internal/service/gpx"
 	"argus-cyclist/internal/service/sim"
 	"argus-cyclist/internal/service/storage"
-	"argus-cyclist/internal/service/workout"
 	"argus-cyclist/internal/service/strava"
-	
+	"argus-cyclist/internal/service/workout"
+
 	"github.com/joho/godotenv"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -45,15 +45,16 @@ import (
 // App is the main application struct exposed to Wails.
 // It orchestrates services, session lifecycle, and runtime events.
 type App struct {
-	ctx              context.Context
-	gpxService       *gpx.Service
-	fitService       *fit.Service
-	physicsEngine    *sim.Engine
-	trainerService   domain.TrainerService
-	storageService   *storage.Service
-	workoutService   *workout.Service
-	activeWorkout    *domain.ActiveWorkout
-	workoutIntensity float64
+	ctx                    context.Context
+	gpxService             *gpx.Service
+	fitService             *fit.Service
+	physicsEngine          *sim.Engine
+	trainerService         domain.TrainerService
+	storageService         *storage.Service
+	workoutService         *workout.Service
+	activeWorkout          *domain.ActiveWorkout
+	workoutIntensity       float64
+	workoutStartTimeOffset float64
 
 	workoutStartTime time.Time
 	isInWorkout      bool
@@ -527,6 +528,7 @@ func (a *App) startSession() string {
 	a.currentDist = 0
 	a.sessionStart = time.Now()
 	a.sessionActiveTime = 0
+	a.workoutStartTimeOffset = 0
 	a.sessionPowerSum = 0
 	a.sessionTicks = 0
 	a.workoutIntensity = 1.0
@@ -822,7 +824,7 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 					currentMode = "ERG"
 				}
 
-				elapsed := a.sessionActiveTime
+				elapsed := a.sessionActiveTime - a.workoutStartTimeOffset
 				timeAccumulator := 0.0
 
 				// Discover which segment we are in.
@@ -875,7 +877,6 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 				// If the time exceeds the total, exit workout mode but CONTINUE the session in SIM mode.
 				if !foundSegment && elapsed > float64(a.activeWorkout.TotalDuration) {
 					a.isInWorkout = false
-					a.activeWorkout = nil
 
 					runtime.EventsEmit(a.ctx, "workout_finished", "completed")
 
@@ -1012,9 +1013,34 @@ func (a *App) LoadWorkout() string {
 	}
 
 	a.activeWorkout = wo
+
+	if a.isRecording {
+		a.workoutStartTimeOffset = a.sessionActiveTime
+		a.isInWorkout = true
+	} else {
+		a.workoutStartTimeOffset = 0
+	}
+
 	// Sends the complete structure to the frontend to draw the graph.
 	runtime.EventsEmit(a.ctx, "workout_loaded", wo)
 	return "Workout Loaded"
+}
+
+// RepeatWorkout allows restarting the currently loaded workout without stopping the session
+func (a *App) RepeatWorkout() string {
+	if a.activeWorkout == nil {
+		return "No workout loaded"
+	}
+
+	if a.isRecording {
+		a.workoutStartTimeOffset = a.sessionActiveTime
+	} else {
+		a.workoutStartTimeOffset = 0
+	}
+
+	a.isInWorkout = true
+	runtime.EventsEmit(a.ctx, "workout_loaded", a.activeWorkout)
+	return "Workout Repeated"
 }
 
 // StartWorkout specifically initiates workout mode.
@@ -1224,7 +1250,7 @@ func (a *App) ConnectStrava() (string, error) {
 		</body>
 		</html>
 		`
-		
+
 		// Success! Send token to the main thread and update the browser window
 		tokenChan <- tokenResp
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -1240,7 +1266,7 @@ func (a *App) ConnectStrava() (string, error) {
 
 	// Build the Authorization URL asking for 'activity:write' permission
 	authURL := fmt.Sprintf("https://www.strava.com/oauth/authorize?client_id=%s&response_type=code&redirect_uri=http://localhost:8080/callback&scope=activity:write,read", clientID)
-	
+
 	// Open the default OS browser
 	runtime.BrowserOpenURL(a.ctx, authURL)
 
@@ -1258,7 +1284,7 @@ func (a *App) ConnectStrava() (string, error) {
 		profile.StravaAccessToken = token.AccessToken
 		profile.StravaRefreshToken = token.RefreshToken
 		profile.StravaExpiresAt = token.ExpiresAt
-		
+
 		if err := a.storageService.UpdateProfile(profile); err != nil {
 			srv.Shutdown(context.Background())
 			return "", fmt.Errorf("failed to save tokens to database: %v", err)
@@ -1280,14 +1306,14 @@ func (a *App) ConnectStrava() (string, error) {
 
 // IsStravaConnected returns true if the current active profile has a Strava token
 func (a *App) IsStravaConnected() bool {
-    profile, err := a.storageService.GetProfile()
-    if err != nil {
-        return false
-    }
-    return profile.StravaAccessToken != ""
+	profile, err := a.storageService.GetProfile()
+	if err != nil {
+		return false
+	}
+	return profile.StravaAccessToken != ""
 }
 
-// UploadLastWorkoutToStrava finds the most recently generated .fit file 
+// UploadLastWorkoutToStrava finds the most recently generated .fit file
 // and uploads it using the active user's Strava token.
 func (a *App) UploadLastWorkoutToStrava() (string, error) {
 	profile, err := a.storageService.GetProfile()
@@ -1297,7 +1323,7 @@ func (a *App) UploadLastWorkoutToStrava() (string, error) {
 
 	if time.Now().Unix() >= profile.StravaExpiresAt {
 		fmt.Println("[STRAVA] Token de Acesso Expirado. Renovando automaticamente...")
-		
+
 		newTokens, err := strava.RefreshToken(profile.StravaRefreshToken)
 		if err != nil {
 			return "", fmt.Errorf("failed to auto-refresh token: %v", err)
@@ -1310,7 +1336,7 @@ func (a *App) UploadLastWorkoutToStrava() (string, error) {
 		if err := a.storageService.UpdateProfile(profile); err != nil {
 			return "", fmt.Errorf("failed to save refreshed token: %v", err)
 		}
-		
+
 		fmt.Println("[STRAVA] Token renovado com sucesso!")
 	}
 
@@ -1331,7 +1357,7 @@ func (a *App) UploadLastWorkoutToStrava() (string, error) {
 			}
 			if info.ModTime().Unix() > lastModTime {
 				lastModTime = info.ModTime().Unix()
-				latestFitFilePath = filepath.Join(workoutsDir, file.Name()) 
+				latestFitFilePath = filepath.Join(workoutsDir, file.Name())
 			}
 		}
 	}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -532,6 +532,15 @@
 
             <div id="workout-list" class="scroll-list">
             </div>
+
+            <div id="workout-completion-actions" class="hidden"
+                style="padding: 15px; display: flex; flex-direction: column; gap: 10px;">
+                <button class="btn-primary" onclick="window.go.main.App.RepeatWorkout()">Repeat Current Workout</button>
+                <button class="btn-secondary" onclick="window.go.main.App.LoadWorkout()">Import New Workout</button>
+                <button class="btn-danger"
+                    onclick="window.go.main.App.UnloadWorkout(); window.workoutCtrl.hide();">Close Panel</button>
+            </div>
+
         </aside>
 
         <div id="routeEditorPanel" class="editor-panel" style="display: none;">

--- a/frontend/src/modules/WorkoutController.js
+++ b/frontend/src/modules/WorkoutController.js
@@ -54,9 +54,11 @@ export class WorkoutController {
             window.runtime.EventsOn("workout_loaded", (wo) => this.loadWorkout(wo));
             window.runtime.EventsOn("workout_status", (state) => this.updateStatus(state));
             window.runtime.EventsOn("workout_finished", (status) => {
-                this.hide();
                 if (status === "completed") {
-                    this.showToast("Workout completed!\n\nSwitched to Free Ride (SIM).\nKeep pedaling to continue, or stop to finish the workout.", 5000);
+                    this.showCompletionActions();
+                    this.showToast("Workout completed!\n\nSwitched to Free Ride (SIM).\nYou can repeat or load a new workout.", 5000);
+                } else {
+                    this.hide();
                 }
             });
             window.runtime.EventsOn("telemetry_update", (data) => this.updateTelemetry(data));
@@ -68,6 +70,16 @@ export class WorkoutController {
                 this.renderGraph(this.lastPct || 0);
             }
         });
+    }
+
+    showCompletionActions() {
+        if (this.list) this.list.classList.add('hidden');
+        const actions = document.getElementById('workout-completion-actions');
+        if (actions) actions.classList.remove('hidden');
+        
+        if (this.elMessage) this.elMessage.innerText = "WORKOUT COMPLETE";
+        if (this.elTarget) this.elTarget.innerText = "--";
+        if (this.elTimer) this.elTimer.innerText = "--:--";
     }
 
     getProp(obj, keys) {
@@ -85,6 +97,10 @@ export class WorkoutController {
         console.log("WORKOUT: Loading...", workout);
         this.activeWorkout = workout;
         this.panel.classList.remove('hidden');
+
+        if (this.list) this.list.classList.remove('hidden');
+        const actions = document.getElementById('workout-completion-actions');
+        if (actions) actions.classList.add('hidden');
 
         setTimeout(() => {
             if (window.mapController && window.mapController.map) {
@@ -127,11 +143,11 @@ export class WorkoutController {
         this.stopMobileWorkoutLoop();
         this.mobileElapsedTime = 0;
         this.currentSegIdx = -1;
-        
+
         const segments = this.getProp(this.activeWorkout, ['segments', 'Segments']) || [];
-        const totalDuration = this.getProp(this.activeWorkout, ['total_duration', 'TotalDuration']) || 
-                              segments.reduce((acc, s) => acc + (this.getProp(s, ['duration', 'DurationSeconds']) || 0), 0);
-        
+        const totalDuration = this.getProp(this.activeWorkout, ['total_duration', 'TotalDuration']) ||
+            segments.reduce((acc, s) => acc + (this.getProp(s, ['duration', 'DurationSeconds']) || 0), 0);
+
         if (totalDuration === 0) return;
 
         this.mobileInterval = setInterval(() => {
@@ -146,7 +162,7 @@ export class WorkoutController {
             for (let i = 0; i < segments.length; i++) {
                 const seg = segments[i];
                 const dur = this.getProp(seg, ['duration', 'DurationSeconds']);
-                
+
                 if (this.mobileElapsedTime <= accumulatedTime + dur) {
                     currentSegment = seg;
                     segmentElapsed = this.mobileElapsedTime - accumulatedTime;
@@ -167,7 +183,7 @@ export class WorkoutController {
             const startFactor = this.getProp(currentSegment, ['start_factor', 'StartFactor']) || 0;
             const endFactor = this.getProp(currentSegment, ['end_factor', 'EndFactor']) || startFactor;
             const dur = this.getProp(currentSegment, ['duration', 'DurationSeconds']);
-            
+
             // Calculate interpolated target power (for Ramps)
             const progress = segmentElapsed / dur;
             const currentFactor = startFactor + (endFactor - startFactor) * progress;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -59,6 +59,8 @@ export function LoadWorkout():Promise<string>;
 
 export function OpenFileFolder(arg1:string):Promise<void>;
 
+export function RepeatWorkout():Promise<string>;
+
 export function ResetAppState():Promise<void>;
 
 export function SaveGeneratedGPX(arg1:string,arg2:Array<main.ExportPoint>):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -110,6 +110,10 @@ export function OpenFileFolder(arg1) {
   return window['go']['main']['App']['OpenFileFolder'](arg1);
 }
 
+export function RepeatWorkout() {
+  return window['go']['main']['App']['RepeatWorkout']();
+}
+
 export function ResetAppState() {
   return window['go']['main']['App']['ResetAppState']();
 }


### PR DESCRIPTION
### Description
This PR introduces the ability to chain workouts together. Previously, when a workout ended, the user was forced back into free simulation (SIM mode) with no way to load a new structured workout without stopping and restarting the entire activity. 

Now, upon completing a workout, the panel displays options to either repeat the current workout or load a new `.zwo` file. This injects the new ERG plan directly into the ongoing session seamlessly, keeping the rider at their current map position.

### Related Issue
Closes #109 

### Changes Included
- **Backend (`app.go`)**: 
  - Introduced `workoutStartTimeOffset` to calculate workout segment times relative to when the workout was started/injected, rather than the total session time.
  - Added the `RepeatWorkout()` function.
  - Updated `LoadWorkout()` to handle mid-session loading securely.
- **Frontend (`index.html`)**: 
  - Fixed the `#workout-panel` DOM structure to ensure correct rendering.
  - Added the `#workout-completion-actions` container with "Repeat", "Import New", and "Close" buttons.
- **Frontend Logic (`WorkoutController.js`)**: 
  - Updated the event listener for `workout_finished` to display the new completion actions instead of immediately closing the panel.

### How to Test
1. Start a ride and load a short `.zwo` workout.
2. Complete the workout. 
3. Observe that the trainer resistance drops back to SIM mode (route gradient) and the completion buttons appear.
4. Click **"Repeat Current Workout"** and verify that the intervals restart correctly from zero.
5. Finish it again, click **"Import New Workout"**, select a different file, and verify the new plan applies perfectly.