### PR TITLE
fix: resolve blank map render on dashboard toggle (#113)

### DIFF
--- a/frontend/src/modules/MapController.js
+++ b/frontend/src/modules/MapController.js
@@ -431,7 +431,7 @@ export class MapController {
         return this.generatedRouteData || [];
     }
 
-async calculateRouteOSRM(pointsArray) {
+    async calculateRouteOSRM(pointsArray) {
         const coordsString = pointsArray.map(p => `${parseFloat(p.lng).toFixed(6)},${parseFloat(p.lat).toFixed(6)}`).join(';');
         const osrmUrl = `https://router.project-osrm.org/route/v1/driving/${coordsString}?overview=full&geometries=geojson`;
 
@@ -604,6 +604,16 @@ async calculateRouteOSRM(pointsArray) {
                     'line-width': 4
                 }
             });
+        }
+    }
+
+    // ========
+    // UI FIXES
+    // ========
+
+    forceResize() {
+        if (this.map) {
+            this.map.resize();
         }
     }
 }

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -159,7 +159,7 @@ export class UIManager {
             this.els.mapContainer.style.display = 'none';
             this.els.hudSidebar.style.display = 'none';
 
-            // --- NEW: Initialize and resize chart ---
+            // --- Initialize and resize chart ---
             this.initLiveChart();
             if (this.liveChartInstance) {
                 setTimeout(() => this.liveChartInstance.resize(), 100);
@@ -168,6 +168,12 @@ export class UIManager {
             this.els.dashboardView.classList.add('hidden');
             this.els.mapContainer.style.display = 'block';
             this.els.hudSidebar.style.display = 'flex';
+
+            setTimeout(() => {
+                if (window.mapController) {
+                    window.mapController.forceResize();
+                }
+            }, 100);
         }
     }
 


### PR DESCRIPTION
## Description
This Pull Request fixes a visual bug (Issue #113) where the WebGL map was not rendering correctly (black screen) after the user toggled from the Dashboard view back to the Map view in Free Ride mode.

The issue occurred because the map library (MapLibre) loses its internal canvas dimensions when the parent container receives `display: none`. When the container reverts to `display: block`, the map does not automatically detect the change without manual interaction.

## Changes Made
- **`MapController.js`**: Added the `forceResize()` method, which safely exposes the map instance's native `.resize()` function.
- **`UIManager.js`**: In the `toggleDashboardMode()` function, a 100ms `setTimeout` block was added when closing the Dashboard. This delay ensures that the DOM has already applied the `display: block` rule before calling `forceResize()`, forcing the map to redraw immediately.

## Related Issue
Closes #113 

## How to Test
1. Start the application in Free Ride mode (without importing a GPX route).
2. Click the toggle button to switch to the Dashboard view.
3. Click the toggle button again to return to the map view.
4. Verify that the map renders immediately, without the need to interact with the mouse (scroll/zoom) or resize the window.

## Checklist
- [x] Code has been tested locally.
- [x] Does not introduce any console errors (DevTools).