### PR TITLE
feat: implement active resistance control for pure FTMS trainers

### DIFF
--- a/internal/service/ble/real.go
+++ b/internal/service/ble/real.go
@@ -324,6 +324,14 @@ func (s *RealService) SetGrade(grade float64) error {
 		msg := fec.EncodeTrackResistance(grade)
 		_, err := s.fecWriteChar.WriteWithoutResponse(msg)
 		return err
+	} else if !s.isFEC && s.trainerPointChar != nil {
+		// Control for Pure FTMS Protocol (Sim Mode / Inclination)
+		// Opcode: 0x03 (Set Target Inclination)
+		// Resolution: 0.1%, Format: sint16 (Little Endian)
+		val := int16(grade * 10.0)
+		msg := []byte{0x03, byte(val & 0xFF), byte(val >> 8)}
+		_, err := s.trainerPointChar.WriteWithoutResponse(msg)
+		return err
 	}
 	return nil
 }
@@ -337,6 +345,15 @@ func (s *RealService) SetPower(watts float64) error {
 		fmt.Printf("[BLE] Setting ERG Power: %.1f W\n", watts)
 		msg := fec.EncodeTargetPower(watts)
 		_, err := s.fecWriteChar.WriteWithoutResponse(msg)
+		return err
+	} else if !s.isFEC && s.trainerPointChar != nil {
+		fmt.Printf("[BLE] Setting ERG Power (FTMS): %.1f W\n", watts)
+		// Control for Pure FTMS Protocol (ERG Mode / Target Power)
+		// Opcode: 0x05 (Set Target Power)
+		// Resolution: 1W, Format: sint16 (Little Endian)
+		val := int16(watts)
+		msg := []byte{0x05, byte(val & 0xFF), byte(val >> 8)}
+		_, err := s.trainerPointChar.WriteWithoutResponse(msg)
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Description
This PR resolves the issue where the simulator could only read telemetry from pure FTMS devices without actively controlling their physical resistance. It introduces bidirectional control for trainers that strictly use the Fitness Machine Service (FTMS) standard, bypassing the need for the ANT+ FE-C over BLE (FEC) protocol.

## Changes Made
- Updated `internal/service/ble/real.go` to handle control commands for pure FTMS protocols.
- **SIM Mode (`SetGrade`):** Added logic to send Opcode `0x03` (Set Target Inclination) with a 0.1% resolution formatted as a Little Endian `sint16`.
- **ERG Mode (`SetPower`):** Added logic to send Opcode `0x05` (Set Target Power) with a 1W resolution formatted as a Little Endian `sint16`.
- Conditionals were added to ensure the software properly routes the resistance commands depending on whether the connected trainer uses FEC or pure FTMS.

## Related Issue
Closes #60

## Testing Notes
- Verified that the `runControlLoop()` remains asynchronous for FEC devices.
- Tested FTMS direct writes (`WriteWithoutResponse`) to the `CharFTMSControl` control point (`0x2AD9`).
- Trainers like the Wahoo Kickr Core should now correctly adjust resistance when a slope changes or an ERG workout interval begins.