### PR TITLE
chore(ui): translate activity metrics labels to English

### DIFF
--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -1071,13 +1071,13 @@ export class UIManager {
             const distKm = (activity.total_distance / 1000).toFixed(2);
 
             document.getElementById('detail-metrics').innerHTML = `
-                <div class="detail-metric-row"><span class="label">Tempo</span><span class="value">${durationMin} min</span></div>
-                <div class="detail-metric-row"><span class="label">Distância</span><span class="value">${distKm} km</span></div>
-                <div class="detail-metric-row"><span class="label">Potência Média</span><span class="value" style="color:var(--power-color)">${activity.avg_power} w</span></div>
-                <div class="detail-metric-row"><span class="label">Potência Normalizada</span><span class="value" style="color:var(--power-color)">${activity.normalized_power || '--'} w</span></div>
+                <div class="detail-metric-row"><span class="label">Duration</span><span class="value">${durationMin} min</span></div>
+                <div class="detail-metric-row"><span class="label">Distance</span><span class="value">${distKm} km</span></div>
+                <div class="detail-metric-row"><span class="label">Average Power</span><span class="value" style="color:var(--power-color)">${activity.avg_power} w</span></div>
+                <div class="detail-metric-row"><span class="label">Normalized Power</span><span class="value" style="color:var(--power-color)">${activity.normalized_power || '--'} w</span></div>
                 <div class="detail-metric-row"><span class="label">Intensity Factor (IF)</span><span class="value">${(activity.intensity_factor || 0).toFixed(2)}</span></div>
                 <div class="detail-metric-row"><span class="label">TSS</span><span class="value">${(activity.tss || 0).toFixed(1)}</span></div>
-                <div class="detail-metric-row"><span class="label">Calorias</span><span class="value">${activity.calories || '--'} kcal</span></div>
+                <div class="detail-metric-row"><span class="label">Calories</span><span class="value">${activity.calories || '--'} kcal</span></div>
             `;
 
             this.renderMasterChart(details);


### PR DESCRIPTION
## Description
This PR updates the labels in the activity details component, translating them from Portuguese to English. This ensures the terminology aligns with standard cycling and fitness applications and standardizes the application's interface language.

## Changes Made
Updated the following labels in the `detail-metrics` HTML injection:
* `Tempo` -> `Duration`
* `Distância` -> `Distance`
* `Potência Média` -> `Average Power`
* `Potência Normalizada` -> `Normalized Power`
* `Calorias` -> `Calories`

*(Note: Intensity Factor and TSS were already using universal acronyms/terms).*

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / Chore (Translation/UI text update)

## How to Test
1. Open an activity details view.
2. Verify that all metrics on the panel (Time, Distance, Average Power, etc.) are now correctly displaying in English.
3. Verify that the dynamic values (`durationMin`, `distKm`, etc.) are still rendering correctly next to the new labels.