### PR TITLE
feat: Heart Rate Recovery (HRR) and Cooldown State (#123)

### DIFF
--- a/app.go
+++ b/app.go
@@ -80,6 +80,11 @@ type App struct {
 	simPower             int16
 	sessionElevationGain float64
 	lastAltitude         float64
+	isCooldown           bool
+	cooldownStart        time.Time
+	peakHR               int
+	hrAt1Min             int
+	hrAt2Min             int
 }
 
 type ExportPoint struct {
@@ -584,6 +589,24 @@ func (a *App) resumeSession() string {
 	return "Recording"
 }
 
+// InitiateCooldown begins the 2-minute Heart Rate Recovery tracking phase.
+func (a *App) InitiateCooldown() (string, error) {
+	a.isCooldown = true
+	a.isPaused = false
+	a.cooldownStart = time.Now()
+
+	a.peakHR = 0
+	if len(a.sessionHRData) > 0 {
+		a.peakHR = a.sessionHRData[len(a.sessionHRData)-1]
+	}
+
+	a.hrAt1Min = 0
+	a.hrAt2Min = 0
+
+	runtime.EventsEmit(a.ctx, "status_change", "COOLDOWN")
+	return "COOLDOWN", nil
+}
+
 // FinishSession finalizes the current training session.
 // It calculates statistics, saves the activity to the database,
 // exports the FIT file, and resets the application state.
@@ -679,6 +702,16 @@ func (a *App) FinishSession() (SessionSummary, error) {
 	fileName := fmt.Sprintf("workout_%s.fit", time.Now().Format("2006-01-02_15-04-05"))
 	fullPath := filepath.Join(workoutsDir, fileName)
 
+	// Lógica para calcular a diferença (queda de bpm)
+	hrr1 := 0
+	if a.hrAt1Min > 0 && a.peakHR > 0 {
+		hrr1 = a.peakHR - a.hrAt1Min
+	}
+	hrr2 := 0
+	if a.hrAt2Min > 0 && a.peakHR > 0 {
+		hrr2 = a.peakHR - a.hrAt2Min
+	}
+
 	activity := domain.Activity{
 		RouteName:         routeName,
 		Filename:          fullPath,
@@ -697,6 +730,10 @@ func (a *App) FinishSession() (SessionSummary, error) {
 		Calories:          calories,
 		CreatedAt:         time.Now(),
 		TimeInHRZones:     hrZones,
+		PeakHR:            a.peakHR,
+		HRR1:              hrr1,
+		HRR2:              hrr2,
+		UploadedToStrava:  false,
 	}
 
 	if err := a.storageService.SaveActivity(activity); err != nil {
@@ -715,6 +752,10 @@ func (a *App) FinishSession() (SessionSummary, error) {
 	a.currentDist = 0
 	a.sessionPowerData = []int{}
 	a.sessionHRData = []int{}
+	a.isCooldown = false
+	a.peakHR = 0
+	a.hrAt1Min = 0
+	a.hrAt2Min = 0
 
 	runtime.EventsEmit(a.ctx, "status_change", "IDLE")
 
@@ -813,6 +854,30 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 			currentPower += a.simPower
 
 			now := time.Now()
+
+			if a.isCooldown {
+				lastUpdate = now
+				elapsed := now.Sub(a.cooldownStart).Seconds()
+				timeLeft := int(120.0 - elapsed)
+
+				if elapsed >= 60.0 && a.hrAt1Min == 0 {
+					a.hrAt1Min = int(currentHR)
+				}
+
+				if elapsed >= 120.0 && a.hrAt2Min == 0 {
+					a.hrAt2Min = int(currentHR)
+					a.isCooldown = false
+
+					summary, _ := a.FinishSession()
+					runtime.EventsEmit(a.ctx, "cooldown_complete", summary)
+				} else {
+					runtime.EventsEmit(a.ctx, "cooldown_update", map[string]interface{}{
+						"time_left":  timeLeft,
+						"current_hr": int(currentHR),
+					})
+				}
+				continue
+			}
 
 			if a.isPaused {
 				lastUpdate = now

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -373,7 +373,19 @@
             </div>
         </div>
     </div>
-
+    <div id="cooldownModal" class="modal-overlay hidden">
+        <div class="modal-content-small text-center" style="text-align: center;">
+            <h3 style="color: var(--zone-4);">Heart Rate Recovery 🫀</h3>
+            <p style="color: var(--text-muted); margin-top: 10px;">Stop pedaling or spin lightly. Measuring your heart's
+                ability to recover...</p>
+            <div style="font-size: 3.5rem; font-family: var(--metric-font); font-weight: bold; margin: 20px 0; color: var(--text-main);"
+                id="cooldownTimer">02:00</div>
+            <div style="font-size: 1.5rem; color: var(--zone-2);" id="cooldownHR">-- bpm</div>
+            <div class="action-buttons" style="justify-content: center; margin-top: 25px;">
+                <button id="btnSkipCooldown" class="btn-secondary">Skip & Save</button>
+            </div>
+        </div>
+    </div>
     <header>
         <div class="brand">ARGUS<span>CYCLIST</span> <span id="filename" class="filename-display"></span></div>
         <div class="header-controls">
@@ -604,6 +616,10 @@
                     <span class="label">Pw:HR Drift</span>
                     <span class="value" id="finish-decoupling"
                         style="display:flex; justify-content:center; align-items:center; gap:4px;">--</span>
+                </div>
+                <div class="stat-box-small">
+                    <span class="label">HRR (1m / 2m)</span>
+                    <span class="value" id="finish-hrr">-- / --</span>
                 </div>
             </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -768,6 +768,22 @@ document.getElementById('btnResume').addEventListener('click', async () => {
 });
 
 document.getElementById('btnFinishSave').addEventListener('click', async () => {
+    try {
+        const res = await window.go.main.App.InitiateCooldown();
+
+        if (res === "SKIP") {
+            await finishWorkout();
+        } else {
+            document.getElementById('confirmModal').classList.remove('active');
+            document.getElementById('cooldownModal').classList.add('active');
+        }
+    } catch (e) {
+        await finishWorkout();
+    }
+});
+
+document.getElementById('btnSkipCooldown').addEventListener('click', async () => {
+    document.getElementById('cooldownModal').classList.remove('active');
     await finishWorkout();
 });
 
@@ -844,6 +860,23 @@ if (window.runtime && !Capacitor.isNativePlatform()) {
     window.runtime.EventsOn("telemetry_update", (data) => {
         ui.updateTelemetry(data, totalRouteDistance);
         mapCtrl.updateCyclistPosition(data.lat, data.lon, data.speed, data);
+    });
+
+    window.runtime.EventsOn("cooldown_update", (data) => {
+        const modal = document.getElementById('cooldownModal');
+        if (modal && modal.classList.contains('active')) {
+            const m = Math.floor(data.time_left / 60);
+            const s = data.time_left % 60;
+            document.getElementById('cooldownTimer').innerText = `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+            document.getElementById('cooldownHR').innerText = `${data.current_hr} bpm`;
+        }
+    });
+
+    window.runtime.EventsOn("cooldown_complete", (summary) => {
+        document.getElementById('cooldownModal').classList.remove('active');
+        if (window.ui) {
+            window.ui.showFinishModal(summary);
+        }
     });
 }
 

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -1020,6 +1020,7 @@ export class UIManager {
             document.getElementById('finish-tss').innerText = summary.activity.tss ? summary.activity.tss.toFixed(1) : '--';
             document.getElementById('finish-cal').innerText = summary.activity.calories ? summary.activity.calories : '--';
             document.getElementById('finish-trimp').innerText = summary.activity.trimp || '--';
+            document.getElementById('finish-hrr').innerText = `${summary.activity.hrr_1 || 0} / ${summary.activity.hrr_2 || 0} bpm`;
 
             const decouplingEl = document.getElementById('finish-decoupling');
             if (decouplingEl) {
@@ -1123,9 +1124,8 @@ export class UIManager {
                 <div class="detail-metric-row"><span class="label">Intensity Factor (IF)</span><span class="value">${(activity.intensity_factor || 0).toFixed(2)}</span></div>
                 <div class="detail-metric-row"><span class="label">TSS</span><span class="value">${(activity.tss || 0).toFixed(1)}</span></div>
                 <div class="detail-metric-row"><span class="label">TRIMP</span><span class="value">${activity.trimp || '--'}</span></div>
-                
                 <div class="detail-metric-row"><span class="label">Aerobic Decoupling (Pw:HR)</span><span class="value">${activity.duration >= 3600 ? (activity.aerobic_decoupling || 0).toFixed(1) + '%' : 'N/A (< 1h)'}</span></div>
-                
+                <div class="detail-metric-row"><span class="label">HRR (1m / 2m)</span><span class="value">${activity.hrr_1 || 0} / ${activity.hrr_2 || 0} bpm</span></div>
                 <div class="detail-metric-row"><span class="label">Calories</span><span class="value">${activity.calories || '--'} kcal</span></div>
             `;
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -55,6 +55,8 @@ export function GetTotalStats():Promise<Record<string, number>>;
 
 export function GetUserProfile():Promise<domain.UserProfile>;
 
+export function InitiateCooldown():Promise<string>;
+
 export function IsStravaConnected():Promise<boolean>;
 
 export function LoadWorkout():Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -102,6 +102,10 @@ export function GetUserProfile() {
   return window['go']['main']['App']['GetUserProfile']();
 }
 
+export function InitiateCooldown() {
+  return window['go']['main']['App']['InitiateCooldown']();
+}
+
 export function IsStravaConnected() {
   return window['go']['main']['App']['IsStravaConnected']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -22,6 +22,9 @@ export namespace domain {
 	    created_at: any;
 	    time_in_hr_zones: Record<string, number>;
 	    uploaded_to_strava: boolean;
+	    peak_hr: number;
+	    hrr_1: number;
+	    hrr_2: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new Activity(source);
@@ -49,6 +52,9 @@ export namespace domain {
 	        this.created_at = this.convertValues(source["created_at"], null);
 	        this.time_in_hr_zones = source["time_in_hr_zones"];
 	        this.uploaded_to_strava = source["uploaded_to_strava"];
+	        this.peak_hr = source["peak_hr"];
+	        this.hrr_1 = source["hrr_1"];
+	        this.hrr_2 = source["hrr_2"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -107,6 +107,9 @@ type Activity struct {
 	CreatedAt         time.Time      `json:"created_at"` // Activity date
 	TimeInHRZones     map[string]int `json:"time_in_hr_zones" gorm:"serializer:json"`
 	UploadedToStrava  bool           `json:"uploaded_to_strava"`
+	PeakHR            int            `json:"peak_hr"`
+    HRR1              int            `json:"hrr_1"`
+    HRR2              int            `json:"hrr_2"`
 }
 
 // BLEDevice represents a Bluetooth device found during the scan.


### PR DESCRIPTION
## Description
This Pull Request implements the Heart Rate Recovery (HRR) metric, measuring the parasympathetic reactivation of the cardiovascular system after a workout. It introduces a new `COOLDOWN` state to the simulation lifecycle, holding the session open for 2 minutes post-workout to track the drop in heart rate.

Closes #123
Completes Epic #119

## Changes Made

### Backend
* **`internal/domain/models.go`**: Added `PeakHR`, `HRR1`, and `HRR2` fields to the `Activity` struct.
* **`app.go`**: 
  * Refactored the state machine in `gameLoop` to prioritize the new `isCooldown` phase over the `isPaused` phase.
  * Added `InitiateCooldown()` to start the 120-second countdown and record the `PeakHR`.
  * Updated `FinishSession()` to calculate the exact bpm drops and save them to the database.

### Frontend
* **`frontend/index.html`**: Added a new modal (`#cooldownModal`) to display the live recovery countdown and the user's current BPM. Added the HRR stat box to the post-workout summary.
* **`frontend/src/main.js`**: Replaced the immediate workout termination on "Finish & Save" with a call to `InitiateCooldown()`, smoothly transitioning the user to the recovery screen.
* **`frontend/src/modules/UIManager.js`**: 
  * Added Wails event listeners for `cooldown_update` and `cooldown_complete` to update the UI timers dynamically.
  * Updated `showFinishModal()` and `openActivityDetail()` to correctly render the saved `hrr_1` and `hrr_2` metrics.

## How to Test
1. Start a session with a connected Heart Rate Monitor.
2. Elevate the heart rate.
3. Click "STOP" and then "Finish & Save".
4. Verify the `COOLDOWN` modal appears with a 2-minute countdown and live HR data.
5. Wait for the countdown to finish (or click "Skip & Save").
6. Check the Post-Workout Summary and the Historical Detail View to ensure the `HRR (1m / 2m)` values are accurately displayed.