### PR TITLE
fix: Strava upload button missing after automatic HRR cooldown

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -872,10 +872,32 @@ if (window.runtime && !Capacitor.isNativePlatform()) {
         }
     });
 
-    window.runtime.EventsOn("cooldown_complete", (summary) => {
+    window.runtime.EventsOn("cooldown_complete", async (summary) => {
         document.getElementById('cooldownModal').classList.remove('active');
         if (window.ui) {
             window.ui.showFinishModal(summary);
+        }
+        
+        try {
+            if (window.go && window.go.main && window.go.main.App.IsStravaConnected) {
+                const isConnected = await window.go.main.App.IsStravaConnected();
+                const btnStrava = document.getElementById('btnUploadStrava');
+
+                if (isConnected) {
+                    btnStrava.classList.remove('hidden');
+                    btnStrava.innerHTML = `
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align: middle; margin-right: 5px;">
+                        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+                    </svg> Upload to Strava`;
+                    btnStrava.disabled = false;
+                    btnStrava.style.backgroundColor = "#FC4C02";
+                } else {
+                    btnStrava.classList.add('hidden');
+                }
+            }
+        } catch (e) {
+            console.log("Strava validation skipped", e);
         }
     });
 }


### PR DESCRIPTION
## Description
This Pull Request fixes a UI bug where the "Upload to Strava" button would not render in the Post-Workout Summary modal if the user waited for the 2-minute Heart Rate Recovery (HRR) cooldown to finish automatically. 

Previously, the Strava API connection check was only tied to the manual `finishWorkout()` function triggered by the "Skip & Save" button. This fix adds the asynchronous Strava validation step directly to the `cooldown_complete` event listener, ensuring the button appears regardless of how the session ends.

## Changes Made
* **`frontend/src/main.js`**: 
  * Updated the Wails `cooldown_complete` event listener to be `async`.
  * Added the `App.IsStravaConnected()` validation block inside the listener to dynamically render the orange Strava upload button upon automatic cooldown completion.

## How to Test
1. Connect your Strava account in the settings.
2. Start a session with a connected Heart Rate Monitor.
3. Click "STOP" and then "Finish & Save" to enter the Cooldown phase.
4. **Do not** click "Skip & Save". Wait the full 2 minutes for the timer to reach `00:00`.
5. Verify that the Post-Workout Summary modal opens automatically AND the orange "Upload to Strava" button is successfully rendered at the bottom.