### PR TITLE
fix: resolve map freeze on GPX import and smooth route curves

### DIFF
--- a/frontend/src/modules/MapController.js
+++ b/frontend/src/modules/MapController.js
@@ -217,6 +217,7 @@ export class MapController {
         if (!this.routeGeoJSON || !this.map) return;
 
         const sourceId = 'route';
+        const outlineSourceId = 'route-continuous';
         const currentTheme = CONFIG.THEMES[this.currentStyleIndex];
 
         const istactical = currentTheme === 'tactical';
@@ -227,7 +228,7 @@ export class MapController {
         const outlineWidth = isSatellite ? 12 : 10;
         const wallColor = isSatellite ? '#ffffff' : '#000000';
 
-        ['route-glow', 'route-line', 'route-case'].forEach(id => {
+        ['route-glow', 'route-line', 'route-case', 'route-outline', 'route'].forEach(id => {
             if (this.map.getLayer(id)) this.map.removeLayer(id);
         });
 
@@ -237,7 +238,34 @@ export class MapController {
             this.map.addSource(sourceId, {
                 type: 'geojson',
                 data: this.routeGeoJSON,
-                lineMetrics: true
+                lineMetrics: false
+            });
+        }
+
+        let continuousCoords = [];
+        if (this.routeGeoJSON.features && this.routeGeoJSON.features.length > 0) {
+            this.routeGeoJSON.features.forEach((f, i) => {
+                if (f.geometry && f.geometry.coordinates && f.geometry.coordinates.length === 2) {
+                    if (i === 0) continuousCoords.push(f.geometry.coordinates[0]);
+                    continuousCoords.push(f.geometry.coordinates[1]);
+                }
+            });
+        }
+
+        const continuousGeoJSON = {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: continuousCoords
+            }
+        };
+
+        if (this.map.getSource(outlineSourceId)) {
+            this.map.getSource(outlineSourceId).setData(continuousGeoJSON);
+        } else {
+            this.map.addSource(outlineSourceId, {
+                type: 'geojson',
+                data: continuousGeoJSON
             });
         }
 
@@ -252,46 +280,36 @@ export class MapController {
             15, wallColor
         ];
 
-        const routeColor = gradientExpression;
+        this.map.addLayer({
+            id: 'route-outline',
+            type: 'line',
+            source: outlineSourceId,
+            layout: {
+                'line-join': 'round',
+                'line-cap': 'round'
+            },
+            paint: {
+                'line-width': outlineWidth,
+                'line-color': outlineColor,
+                'line-opacity': outlineOpacity,
+                'line-blur': 0
+            }
+        });
 
-        if (this.map.getLayer('route-outline')) {
-            this.map.setPaintProperty('route-outline', 'line-color', outlineColor);
-            this.map.setPaintProperty('route-outline', 'line-opacity', outlineOpacity);
-            this.map.setPaintProperty('route-outline', 'line-width', outlineWidth);
-        } else {
-            this.map.addLayer({
-                id: 'route-outline',
-                type: 'line',
-                source: sourceId,
-                layout: { 'line-join': 'round', 'line-cap': 'round' },
-                paint: {
-                    'line-width': outlineWidth,
-                    'line-color': outlineColor,
-                    'line-opacity': outlineOpacity,
-                    'line-blur': 0
-                }
-            });
-        }
-
-        if (this.map.getLayer('route')) {
-            this.map.setPaintProperty('route', 'line-color', routeColor);
-            this.map.setPaintProperty('route', 'line-width', istactical ? 8 : 6);
-        } else {
-            this.map.addLayer({
-                id: 'route',
-                type: 'line',
-                source: sourceId,
-                layout: {
-                    'line-join': istactical ? 'miter' : 'round',
-                    'line-cap': istactical ? 'square' : 'round'
-                },
-                paint: {
-                    'line-width': istactical ? 8 : 6,
-                    'line-color': routeColor,
-                    'line-opacity': 1.0
-                }
-            });
-        }
+        this.map.addLayer({
+            id: 'route',
+            type: 'line',
+            source: sourceId,
+            layout: {
+                'line-join': 'bevel',
+                'line-cap': 'butt'
+            },
+            paint: {
+                'line-width': istactical ? 8 : 6,
+                'line-color': gradientExpression,
+                'line-opacity': 1.0
+            }
+        });
 
         const labels = this.map.getStyle().layers.find(l => l.type === 'symbol');
         if (labels) {


### PR DESCRIPTION
## Description
This PR fixes the critical performance issue where the map freezes and the UI becomes unresponsive after importing a GPX route. It also resolves the visual glitch where sharp curves appeared jagged or had gaps when applying simpler geometry rendering.

**The root causes were:**
1. **WebWorker Overload:** The GPX route is parsed as a `FeatureCollection` of thousands of individual 2-point segments (to allow for data-driven gradient styling based on elevation grade). Passing `lineMetrics: true` to this source forced MapLibre to calculate vector distances for *every single segment*, instantly blocking the main thread.
2. **GPU Overdraw:** Using `line-cap: 'round'` on thousands of tiny, disconnected segments forced the GPU to draw overlapping circles at every coordinate, destroying the frame rate.
3. **Visual Gaps:** Switching to `line-cap: 'butt'` fixed the FPS but exposed gaps ("V" shapes) in tight curves because the segments were physically disconnected.

### Solution: The "Dual Source" Technique
To achieve both maximum performance (60 FPS) and perfect visual quality (smooth, rounded curves), `MapController.js` now uses two synchronized sources:
* **Outline Layer (`route-continuous`):** Stitches the segmented coordinates into a single, continuous `LineString` behind the scenes. Because it's a single line, we can safely use `line-cap: 'round'` and `line-join: 'round'` without performance hits. This creates a smooth visual "bed" for the route, covering any gaps.
* **Gradient Layer (`route`):** Keeps the original segmented `FeatureCollection` to paint the data-driven color gradient (`grade`), but uses extremely cheap `line-cap: 'butt'` and `line-join: 'bevel'`. 

Closes #143 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance optimization

## How Has This Been Tested?
- [x] Imported a large/multi-hour GPX file.
- [x] Verified that the MapLibre instance loads the route instantly without freezing the browser tab.
- [x] Verified that zooming, panning, and dragging remain fluid.
- [x] Inspected tight curves and hairpins to ensure there are no jagged edges or gaps in the route line.