### PR TITLE
docs: Add Windows SmartScreen troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,15 @@ To start the application in development mode (with Hot Reload):
 
 ```bash
 wails dev
+```
+
+## Troubleshooting: Windows "Protect your PC" Warning
+
+When launching the downloaded `.exe` on Windows for the first time, you may encounter a blue "Windows protected your PC" (Microsoft Defender SmartScreen) warning.
+
+This happens because Argus Cyclist is an independent open-source project and the executable is currently not signed with a paid Authenticode Code Signing Certificate. The application is completely safe.
+
+**To run the simulator:**
+
+1. Click on **More info** text in the warning dialog.
+2. Click the **Run anyway** button that appears at the bottom.


### PR DESCRIPTION
## Description
This PR addresses the Windows Defender SmartScreen "Protect your PC" warning that users encounter when running the unsigned `.exe`. 

Closes #157 

## Changes Made
* Added a `Troubleshooting` section to the `README.md` with explicit instructions on how to bypass the SmartScreen warning by clicking "More info" -> "Run anyway".
* Completed the investigation regarding Authenticode Code Signing Certificates (findings documented in the issue).

## Checklist
- [x] README.md updated with clear instructions.
- [x] Code signing certificate costs and processes investigated.