### PR TITLE
feat: Native Fitness Assessment Protocols (FTP / VO2Max) and Data-Only HUD

### DIFF
--- a/app.go
+++ b/app.go
@@ -96,6 +96,8 @@ type ExportPoint struct {
 type SessionSummary struct {
 	Activity domain.Activity `json:"activity"`
 	Zones    fit.TimeInZones `json:"zones"`
+	NewFTP   int             `json:"new_ftp"`
+	NewMaxHR int             `json:"new_max_hr"`
 }
 
 // ActivityDetails contains the time-series data for the charts
@@ -611,6 +613,21 @@ func (a *App) InitiateCooldown() (string, error) {
 // It calculates statistics, saves the activity to the database,
 // exports the FIT file, and resets the application state.
 func (a *App) FinishSession() (SessionSummary, error) {
+	newFTP := 0
+	if a.activeWorkout != nil && a.activeWorkout.IsTest {
+		switch a.activeWorkout.TestType {
+		case "ramp":
+			best1 := a.calculateMMP(a.sessionPowerData, 60)
+			newFTP = int(float64(best1) * 0.75)
+		case "ftp20":
+			best20 := a.calculateMMP(a.sessionPowerData, 1200)
+			newFTP = int(float64(best20) * 0.95)
+		case "vo2max5":
+			best5 := a.calculateMMP(a.sessionPowerData, 300)
+			newFTP = int(float64(best5) * 0.80)
+		}
+	}
+
 	if !a.isRecording {
 		return SessionSummary{}, fmt.Errorf("not recording")
 	}
@@ -702,7 +719,6 @@ func (a *App) FinishSession() (SessionSummary, error) {
 	fileName := fmt.Sprintf("workout_%s.fit", time.Now().Format("2006-01-02_15-04-05"))
 	fullPath := filepath.Join(workoutsDir, fileName)
 
-	// Lógica para calcular a diferença (queda de bpm)
 	hrr1 := 0
 	if a.hrAt1Min > 0 && a.peakHR > 0 {
 		hrr1 = a.peakHR - a.hrAt1Min
@@ -762,6 +778,8 @@ func (a *App) FinishSession() (SessionSummary, error) {
 	return SessionSummary{
 		Activity: activity,
 		Zones:    zones,
+		NewFTP:   newFTP,
+		NewMaxHR: sessionMaxHR,
 	}, nil
 }
 
@@ -939,43 +957,49 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 				elapsed := a.sessionActiveTime - a.workoutStartTimeOffset
 				timeAccumulator := 0.0
 
-				// Discover which segment we are in.
 				foundSegment := false
 				for i, seg := range a.activeWorkout.Segments {
 					segDur := float64(seg.DurationSeconds)
 
-					// Check if the elapsed time falls within this segment.
 					if elapsed >= timeAccumulator && elapsed < (timeAccumulator+segDur) {
 						foundSegment = true
 						currentSegmentIdx = seg.Index
 						workoutName = a.activeWorkout.Metadata.Name
-
-						// Time calculations
 						segmentElapsed := elapsed - timeAccumulator
 						remainingSegmentTime = int(segDur - segmentElapsed)
 
-						// Linear Power Interpolation (Supports Ramps and Steady)
 						progress := segmentElapsed / segDur
 						targetFactor := seg.StartFactor + (seg.EndFactor-seg.StartFactor)*progress
 
 						userFTP := float64(a.GetUserProfile().FTP)
 						if userFTP == 0 {
 							userFTP = 200
-						} // Safe fallback
-
+						}
 						targetWatts = int(targetFactor * userFTP * a.workoutIntensity)
 
-						// Next interval forecast for the UI
+						if seg.FreeRide {
+							if currentMode != "SIM" {
+								a.trainerService.SetTrainerMode("SIM")
+								currentMode = "SIM"
+							}
+							if math.Abs(1.0-lastSentGrade) > 0.1 {
+								a.trainerService.SetGrade(1.0)
+								lastSentGrade = 1.0
+							}
+						} else {
+							if currentMode != "ERG" {
+								a.trainerService.SetTrainerMode("ERG")
+								currentMode = "ERG"
+							}
+							if targetWatts != lastSentPower {
+								a.trainerService.SetPower(float64(targetWatts))
+								lastSentPower = targetWatts
+							}
+						}
+
 						if i+1 < len(a.activeWorkout.Segments) {
 							nextTarget = int(a.activeWorkout.Segments[i+1].StartFactor * userFTP)
 						}
-
-						// Send command to Roll (only if significantly changed so as not to flood BLE)
-						if targetWatts != lastSentPower {
-							a.trainerService.SetPower(float64(targetWatts))
-							lastSentPower = targetWatts
-						}
-
 						break
 					}
 					timeAccumulator += segDur
@@ -1045,15 +1069,24 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 
 			// 2. Training State Package (Only if you are training)
 			if a.isInWorkout {
+				isFreeRide := false
+				segDuration := 0
+				if currentSegmentIdx >= 0 && currentSegmentIdx < len(a.activeWorkout.Segments) {
+					isFreeRide = a.activeWorkout.Segments[currentSegmentIdx].FreeRide
+					segDuration = a.activeWorkout.Segments[currentSegmentIdx].DurationSeconds
+				}
+
 				workoutState := domain.WorkoutState{
 					IsActive:          true,
 					WorkoutName:       workoutName,
 					CurrentSegmentIdx: currentSegmentIdx,
 					SegmentTimeRemain: remainingSegmentTime,
+					SegmentDuration:   segDuration,
 					TargetPower:       targetWatts,
 					NextTargetPower:   nextTarget,
 					CompletionPercent: completionPct,
 					IntensityPct:      int(a.workoutIntensity * 100),
+					IsFreeRide:        isFreeRide,
 				}
 				runtime.EventsEmit(a.ctx, "workout_status", workoutState)
 			}
@@ -1558,4 +1591,30 @@ func (a *App) DisconnectStrava() error {
 		return fmt.Errorf("failed to clear tokens: %v", err)
 	}
 	return nil
+}
+
+func (a *App) GetFitnessTests() []domain.ActiveWorkout {
+	return workout.GetBuiltInAssessments()
+}
+
+func (a *App) SetBuiltInWorkout(testType string) string {
+    tests := workout.GetBuiltInAssessments()
+    
+    for _, t := range tests {
+        if t.TestType == testType {
+            wo := t
+            a.activeWorkout = &wo
+            
+            if a.isRecording {
+                a.workoutStartTimeOffset = a.sessionActiveTime
+                a.isInWorkout = true
+            } else {
+                a.workoutStartTimeOffset = 0
+            }
+            
+            runtime.EventsEmit(a.ctx, "workout_loaded", wo)
+            return "Loaded"
+        }
+    }
+    return "Not found"
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -421,6 +421,7 @@
             <button id="btnOpenEditor" class="btn-import" onclick="window.ui.startRouteEditor()">
                 Create Route
             </button>
+            <button id="btnFitnessTests" class="btn-import">Assessments</button>
             <button id="btnLoadWorkout" class="btn-import">Load Workout</button>
             <button id="btnImport" class="btn-import">Import GPX</button>
             <button id="btnAction" class="btn-action btn-start hidden">START RIDE</button>
@@ -802,6 +803,21 @@
                         <div id="mmpChart" style="width: 100%; height: 380px;"></div>
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="fitnessTestModal" class="modal-overlay hidden">
+        <div class="modal-content-small" style="width: 500px; max-width: 90%;">
+            <div class="modal-header" style="display:flex; justify-content: space-between;">
+                <h2 style="margin: 0; color: var(--zone-4);">Physiological Assessments</h2>
+                <button class="close-btn"
+                    style="background:none; border:none; color:#fff; font-size:24px; cursor:pointer;"
+                    onclick="document.getElementById('fitnessTestModal').classList.remove('active'); document.getElementById('fitnessTestModal').classList.add('hidden')">×</button>
+            </div>
+            <p style="color: var(--text-muted); margin-top: 10px; font-size: 14px;">Select an assessment to establish
+                your baseline metrics.</p>
+            <div id="fitnessTestList" style="display: flex; flex-direction: column; gap: 15px; margin-top: 20px;">
             </div>
         </div>
     </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,12 +1,18 @@
-/*
-    Argus Cyclist - Virtual Cycling Environment for interactive bicycling experiments.
-    Copyright (C) 2026  Paulo Sérgio
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-*/
+// Argus Cyclist - Virtual Cycling Environment for interactive bicycling experiments.
+// Copyright (C) 2026  Paulo Sérgio
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import './styles/main.css';
 import { MapController } from './modules/MapController.js';
@@ -699,6 +705,24 @@ async function finishWorkout() {
         const sessionSummary = await window.go.main.App.FinishSession();
         ui.showFinishModal(sessionSummary);
 
+        if (sessionSummary.new_ftp > 0) {
+            setTimeout(() => {
+                const msg = `Physiological Assessment Complete!\n\nNew Estimated FTP: ${sessionSummary.new_ftp} W\nMax HR Reached: ${sessionSummary.new_max_hr} BPM\n\nWould you like to update your profile with these new metrics?`;
+                if (confirm(msg)) {
+                    window.go.main.App.GetUserProfile().then(profile => {
+                        profile.ftp = sessionSummary.new_ftp;
+                        if (sessionSummary.new_max_hr > profile.max_hr) {
+                            profile.max_hr = sessionSummary.new_max_hr;
+                        }
+                        window.go.main.App.UpdateUserProfile(profile).then(() => {
+                            alert("Profile successfully updated!");
+                            if (window.ui) window.ui.loadUserProfile();
+                        });
+                    });
+                }
+            }, 1000);
+        }
+
         try {
             if (window.go.main.App.IsStravaConnected) {
                 const isConnected = await window.go.main.App.IsStravaConnected();
@@ -797,6 +821,62 @@ document.getElementById('btnDiscard').addEventListener('click', async () => {
     }
 });
 
+document.getElementById('btnFitnessTests').addEventListener('click', async () => {
+    if (Capacitor.isNativePlatform()) { alert("Fitness Tests not available on mobile yet."); return; }
+    try {
+        if (!window.go || !window.go.main) return;
+
+        const tests = await window.go.main.App.GetFitnessTests();
+
+        if (!tests || !Array.isArray(tests)) {
+            alert("The tests were not found in memory. You need to restart 'wails dev' in the terminal for it to recognize the new function in app.go.!");
+            return;
+        }
+
+        const list = document.getElementById('fitnessTestList');
+        list.innerHTML = '';
+
+        tests.forEach(test => {
+            const btn = document.createElement('div');
+            btn.style.cssText = "background: var(--bg-elevated); padding: 15px; border-radius: 8px; cursor: pointer; border: 2px solid transparent; transition: all 0.2s ease; transform: scale(1); box-shadow: 0 4px 6px rgba(0,0,0,0.1);";
+
+            btn.innerHTML = `
+                <h4 style="margin:0 0 5px 0; color: #fff;">${test.metadata.name}</h4>
+                <p style="margin:0; font-size: 12px; color: var(--text-muted);">${test.metadata.description}</p>
+                <div style="margin-top: 10px; font-size: 11px; font-weight: bold; color: var(--zone-3);">DURATION: ${Math.round(test.total_duration / 60)} MIN</div>
+            `;
+
+            btn.onmouseover = () => {
+                btn.style.borderColor = "var(--zone-4)";
+                btn.style.transform = "scale(1.03)";
+                btn.style.background = "rgba(255, 255, 255, 0.05)";
+                btn.style.boxShadow = "0 8px 15px rgba(0,0,0,0.4)";
+            };
+            btn.onmouseout = () => {
+                btn.style.borderColor = "transparent";
+                btn.style.transform = "scale(1)";
+                btn.style.background = "var(--bg-elevated)";
+                btn.style.boxShadow = "0 4px 6px rgba(0,0,0,0.1)";
+            };
+
+            btn.onclick = async () => {
+                const modal = document.getElementById('fitnessTestModal');
+                modal.classList.remove('active');
+                modal.classList.add('hidden');
+
+                await window.go.main.App.SetBuiltInWorkout(test.test_type);
+                window.ui.els.btnAction.classList.remove('hidden');
+            };
+            list.appendChild(btn);
+        });
+
+        const modal = document.getElementById('fitnessTestModal');
+        modal.classList.remove('hidden');
+        modal.classList.add('active');
+
+    } catch (e) { alert("Error loading tests: " + e); }
+});
+
 
 // =======================
 // KEYBOARD DEBUG CONTROLS
@@ -877,7 +957,7 @@ if (window.runtime && !Capacitor.isNativePlatform()) {
         if (window.ui) {
             window.ui.showFinishModal(summary);
         }
-        
+
         try {
             if (window.go && window.go.main && window.go.main.App.IsStravaConnected) {
                 const isConnected = await window.go.main.App.IsStravaConnected();

--- a/frontend/src/modules/WorkoutController.js
+++ b/frontend/src/modules/WorkoutController.js
@@ -76,7 +76,6 @@ export class WorkoutController {
         if (this.list) this.list.classList.add('hidden');
         const actions = document.getElementById('workout-completion-actions');
         if (actions) actions.classList.remove('hidden');
-        
         if (this.elMessage) this.elMessage.innerText = "WORKOUT COMPLETE";
         if (this.elTarget) this.elTarget.innerText = "--";
         if (this.elTimer) this.elTimer.innerText = "--:--";
@@ -102,6 +101,32 @@ export class WorkoutController {
         const actions = document.getElementById('workout-completion-actions');
         if (actions) actions.classList.add('hidden');
 
+        const isTest = this.getProp(workout, ['is_test', 'IsTest']);
+        if (isTest) {
+            document.getElementById('map-container').style.display = 'none';
+            const footer = document.querySelector('footer');
+            if (footer) footer.style.display = 'none';
+
+            const leftSidebar = document.querySelector('.hud-sidebar:not(#workout-panel)');
+            if (leftSidebar) leftSidebar.style.display = 'none';
+
+            document.getElementById('dashboard-view').classList.remove('hidden');
+
+            if (window.ui) {
+                window.ui.isDashboardMode = true;
+                window.ui.initLiveChart();
+                setTimeout(() => { if (window.ui.liveChartInstance) window.ui.liveChartInstance.resize(); }, 150);
+            }
+        } else {
+            document.getElementById('map-container').style.display = '';
+            document.getElementById('dashboard-view').classList.add('hidden');
+            const footer = document.querySelector('footer');
+            if (footer) footer.style.display = '';
+
+            const leftSidebar = document.querySelector('.hud-sidebar:not(#workout-panel)');
+            if (leftSidebar) leftSidebar.style.display = '';
+        }
+
         setTimeout(() => {
             if (window.mapController && window.mapController.map) {
                 window.mapController.map.resize();
@@ -124,6 +149,19 @@ export class WorkoutController {
         this.panel.classList.add('hidden');
         this.activeWorkout = null;
         this.stopMobileWorkoutLoop();
+
+        document.getElementById('map-container').style.display = '';
+        document.getElementById('dashboard-view').classList.add('hidden');
+
+        const footer = document.querySelector('footer');
+        if (footer) footer.style.display = '';
+
+        const leftSidebar = document.querySelector('.hud-sidebar:not(#workout-panel)');
+        if (leftSidebar) leftSidebar.style.display = '';
+
+        if (window.ui) {
+            window.ui.isDashboardMode = false;
+        }
 
         setTimeout(() => {
             if (window.mapController && window.mapController.map) {
@@ -253,7 +291,29 @@ export class WorkoutController {
         const currentIdx = this.getProp(state, ['current_segment_index', 'CurrentSegmentIdx']);
         const segDuration = this.getProp(state, ['segment_duration', 'SegmentDuration']);
 
-        this.elTarget.innerText = `${targetPower}w`;
+        const isFreeRide = this.getProp(state, ['is_free_ride', 'IsFreeRide']);
+
+        if (isFreeRide) {
+            this.elTarget.innerText = "FREE RIDE";
+            this.elTarget.style.color = "#3498db";
+            this.elMessage.innerText = "FREE RIDE - CONTROL YOUR GEARS";
+            this.elMessage.style.color = "#3498db";
+        } else {
+            this.elTarget.innerText = `${targetPower}w`;
+            this.elTarget.style.color = "";
+            this.elMessage.style.color = "";
+        }
+
+        if (window.ui && window.ui.isDashboardMode) {
+            const dashPowerSub = document.getElementById('dash-wkg');
+            if (dashPowerSub) {
+                if (isFreeRide) {
+                    dashPowerSub.innerHTML = `<span style="color:#3498db; font-weight:bold; font-size:1.1rem; letter-spacing:1px;">TARGET: FREE RIDE</span>`;
+                } else {
+                    dashPowerSub.innerHTML = `<span style="color:#f1c40f; font-weight:bold; font-size:1.1rem; letter-spacing:1px;">TARGET: ${targetPower} W</span>`;
+                }
+            }
+        }
 
         const intensityPct = this.getProp(state, ['intensity_pct', 'IntensityPct']);
         if (intensityPct && this.elIntensity) {
@@ -277,7 +337,9 @@ export class WorkoutController {
             if (curr) {
                 curr.classList.add('active');
                 curr.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                this.elMessage.innerText = this.getSegmentTypeLabel(currentIdx);
+                if (!isFreeRide) {
+                    this.elMessage.innerText = this.getSegmentTypeLabel(currentIdx);
+                }
             }
         }
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -43,6 +43,8 @@ export function GetCareerDashboard():Promise<main.CareerDashboard>;
 
 export function GetElevationProfile():Promise<Array<number>>;
 
+export function GetFitnessTests():Promise<Array<domain.ActiveWorkout>>;
+
 export function GetLocalAccounts():Promise<Array<storage.ProfileSummary>>;
 
 export function GetMonthlyActivities(arg1:number,arg2:number):Promise<Array<domain.Activity>>;
@@ -78,6 +80,8 @@ export function SelectGPX():Promise<string>;
 export function SelectLocalAccount(arg1:string):Promise<string>;
 
 export function SelectProfileImage():Promise<string>;
+
+export function SetBuiltInWorkout(arg1:string):Promise<string>;
 
 export function SetPowerTarget(arg1:number):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -78,6 +78,10 @@ export function GetElevationProfile() {
   return window['go']['main']['App']['GetElevationProfile']();
 }
 
+export function GetFitnessTests() {
+  return window['go']['main']['App']['GetFitnessTests']();
+}
+
 export function GetLocalAccounts() {
   return window['go']['main']['App']['GetLocalAccounts']();
 }
@@ -148,6 +152,10 @@ export function SelectLocalAccount(arg1) {
 
 export function SelectProfileImage() {
   return window['go']['main']['App']['SelectProfileImage']();
+}
+
+export function SetBuiltInWorkout(arg1) {
+  return window['go']['main']['App']['SetBuiltInWorkout'](arg1);
 }
 
 export function SetPowerTarget(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,5 +1,163 @@
 export namespace domain {
 	
+	export class WorkoutSegment {
+	    index: number;
+	    type: string;
+	    duration: number;
+	    start_factor: number;
+	    end_factor: number;
+	    text: string;
+	    free_ride: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new WorkoutSegment(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.index = source["index"];
+	        this.type = source["type"];
+	        this.duration = source["duration"];
+	        this.start_factor = source["start_factor"];
+	        this.end_factor = source["end_factor"];
+	        this.text = source["text"];
+	        this.free_ride = source["free_ride"];
+	    }
+	}
+	export class ZWOStep {
+	    duration?: number;
+	    power?: number;
+	    power_low?: number;
+	    power_high?: number;
+	    repeat?: number;
+	    on_duration?: number;
+	    on_power?: number;
+	    off_duration?: number;
+	    off_power?: number;
+	    cadence?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new ZWOStep(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.duration = source["duration"];
+	        this.power = source["power"];
+	        this.power_low = source["power_low"];
+	        this.power_high = source["power_high"];
+	        this.repeat = source["repeat"];
+	        this.on_duration = source["on_duration"];
+	        this.on_power = source["on_power"];
+	        this.off_duration = source["off_duration"];
+	        this.off_power = source["off_power"];
+	        this.cadence = source["cadence"];
+	    }
+	}
+	export class ZWOWorkout {
+	    steps: ZWOStep[];
+	
+	    static createFrom(source: any = {}) {
+	        return new ZWOWorkout(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.steps = this.convertValues(source["steps"], ZWOStep);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class ZWOFile {
+	    name: string;
+	    description: string;
+	    author: string;
+	    workout: ZWOWorkout;
+	
+	    static createFrom(source: any = {}) {
+	        return new ZWOFile(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
+	        this.description = source["description"];
+	        this.author = source["author"];
+	        this.workout = this.convertValues(source["workout"], ZWOWorkout);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class ActiveWorkout {
+	    metadata: ZWOFile;
+	    segments: WorkoutSegment[];
+	    total_duration: number;
+	    is_test: boolean;
+	    test_type: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ActiveWorkout(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.metadata = this.convertValues(source["metadata"], ZWOFile);
+	        this.segments = this.convertValues(source["segments"], WorkoutSegment);
+	        this.total_duration = source["total_duration"];
+	        this.is_test = source["is_test"];
+	        this.test_type = source["test_type"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class Activity {
 	    id: number;
 	    route_name: string;
@@ -177,6 +335,9 @@ export namespace domain {
 		    return a;
 		}
 	}
+	
+	
+	
 
 }
 
@@ -317,6 +478,8 @@ export namespace main {
 	export class SessionSummary {
 	    activity: domain.Activity;
 	    zones: fit.TimeInZones;
+	    new_ftp: number;
+	    new_max_hr: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new SessionSummary(source);
@@ -326,6 +489,8 @@ export namespace main {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.activity = this.convertValues(source["activity"], domain.Activity);
 	        this.zones = this.convertValues(source["zones"], fit.TimeInZones);
+	        this.new_ftp = source["new_ftp"];
+	        this.new_max_hr = source["new_max_hr"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -408,6 +573,25 @@ export namespace storage {
 	        this.level = source["level"];
 	        this.total_km = source["total_km"];
 	        this.total_time = source["total_time"];
+	    }
+	}
+
+}
+
+export namespace xml {
+	
+	export class Name {
+	    Space: string;
+	    Local: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new Name(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.Space = source["Space"];
+	        this.Local = source["Local"];
 	    }
 	}
 

--- a/internal/domain/workout.go
+++ b/internal/domain/workout.go
@@ -59,12 +59,15 @@ type WorkoutSegment struct {
 	StartFactor     float64 `json:"start_factor"`
 	EndFactor       float64 `json:"end_factor"`
 	Text            string  `json:"text"`
+	FreeRide        bool    `json:"free_ride"`
 }
 
 type ActiveWorkout struct {
 	Metadata      ZWOFile          `json:"metadata"`
 	Segments      []WorkoutSegment `json:"segments"`
 	TotalDuration int              `json:"total_duration"`
+	IsTest        bool             `json:"is_test"`   // Indicates whether the session is an aptitude test.
+	TestType      string           `json:"test_type"` // "ramp", "ftp20", "vo2max5"
 }
 
 // Structure for sending state to the Frontend
@@ -78,4 +81,5 @@ type WorkoutState struct {
 	NextTargetPower   int     `json:"next_target_power"`
 	CompletionPercent float64 `json:"completion_percent"`
 	IntensityPct      int     `json:"intensity_pct"`
+	IsFreeRide        bool    `json:"is_free_ride"`
 }

--- a/internal/service/workout/builtin.go
+++ b/internal/service/workout/builtin.go
@@ -1,0 +1,109 @@
+// Argus Cyclist - Virtual Cycling Environment for interactive bicycling experiments.
+// Copyright (C) 2026  Paulo Sérgio
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package workout
+
+import (
+	"argus-cyclist/internal/domain"
+)
+
+func GetBuiltInAssessments() []domain.ActiveWorkout {
+	return []domain.ActiveWorkout{
+		createRampTest(),
+		create20MinFTPTest(),
+		create5MinVO2MaxTest(),
+	}
+}
+
+func createRampTest() domain.ActiveWorkout {
+	segments := []domain.WorkoutSegment{
+		{Index: 0, Type: "Warmup", DurationSeconds: 300, StartFactor: 0.50, EndFactor: 0.50, Text: "Warmup: Spin easy", FreeRide: false},
+	}
+
+	idx := 1
+	for p := 0.56; p <= 1.50; p += 0.06 {
+		segments = append(segments, domain.WorkoutSegment{
+			Index:           idx,
+			Type:            "Active",
+			DurationSeconds: 60,
+			StartFactor:     p,
+			EndFactor:       p,
+			Text:            "Hold target power!",
+			FreeRide:        false,
+		})
+		idx++
+	}
+
+	return domain.ActiveWorkout{
+		Metadata: domain.ZWOFile{
+			Name:        "Ramp Test (FTP)",
+			Description: "Incremental test to exhaustion. Resistance increases every minute. FTP = 75% of best 1-minute power.",
+			Author:      "Argus Cyclist",
+		},
+		IsTest:        true,
+		TestType:      "ramp",
+		Segments:      segments,
+		TotalDuration: 300 + ((idx - 1) * 60),
+	}
+}
+
+func create20MinFTPTest() domain.ActiveWorkout {
+	segments := []domain.WorkoutSegment{
+		{Index: 0, Type: "Warmup", DurationSeconds: 1200, StartFactor: 0.50, EndFactor: 0.70, Text: "Progressive warmup", FreeRide: false},
+		{Index: 1, Type: "Active", DurationSeconds: 300, StartFactor: 1.10, EndFactor: 1.10, Text: "Clearing effort: Wake up your legs!", FreeRide: false},
+		{Index: 2, Type: "Rest", DurationSeconds: 600, StartFactor: 0.50, EndFactor: 0.50, Text: "Recover for the test", FreeRide: false},
+		{Index: 3, Type: "Active", DurationSeconds: 1200, StartFactor: 1.05, EndFactor: 1.05, Text: "20 MIN TEST: Find your pace!", FreeRide: true},
+		{Index: 4, Type: "Cooldown", DurationSeconds: 600, StartFactor: 0.50, EndFactor: 0.40, Text: "Cooldown", FreeRide: false},
+	}
+
+	return domain.ActiveWorkout{
+		Metadata: domain.ZWOFile{
+			Name:        "20-Min FTP Test",
+			Description: "Hunter Allen/Coggan protocol. Includes activation and 20 minutes free riding. FTP = 95% of average power.",
+			Author:      "Argus Cyclist",
+		},
+		IsTest:        true,
+		TestType:      "ftp20",
+		Segments:      segments,
+		TotalDuration: 3900,
+	}
+}
+
+func create5MinVO2MaxTest() domain.ActiveWorkout {
+	segments := []domain.WorkoutSegment{
+		{Index: 0, Type: "Warmup", DurationSeconds: 900, StartFactor: 0.60, EndFactor: 0.60, Text: "Easy spin", FreeRide: false},
+		{Index: 1, Type: "Active", DurationSeconds: 60, StartFactor: 1.15, EndFactor: 1.15, Text: "High cadence", FreeRide: false},
+		{Index: 2, Type: "Rest", DurationSeconds: 60, StartFactor: 0.50, EndFactor: 0.50, Text: "Recover", FreeRide: false},
+		{Index: 3, Type: "Active", DurationSeconds: 60, StartFactor: 1.15, EndFactor: 1.15, Text: "High cadence", FreeRide: false},
+		{Index: 4, Type: "Rest", DurationSeconds: 60, StartFactor: 0.50, EndFactor: 0.50, Text: "Recover", FreeRide: false},
+		{Index: 5, Type: "Active", DurationSeconds: 60, StartFactor: 1.15, EndFactor: 1.15, Text: "Final effort", FreeRide: false},
+		{Index: 6, Type: "Rest", DurationSeconds: 300, StartFactor: 0.50, EndFactor: 0.50, Text: "Get ready", FreeRide: false},
+		{Index: 7, Type: "Active", DurationSeconds: 300, StartFactor: 1.20, EndFactor: 1.20, Text: "VO2 MAX TEST: 5 MIN ALL OUT!", FreeRide: true},
+		{Index: 8, Type: "Cooldown", DurationSeconds: 600, StartFactor: 0.40, EndFactor: 0.40, Text: "Cooldown", FreeRide: false},
+	}
+
+	return domain.ActiveWorkout{
+		Metadata: domain.ZWOFile{
+			Name:        "5-Min VO2Max (MAP) Test",
+			Description: "Measures your Maximum Aerobic Power (MAP) based on the Hunter Allen protocol.",
+			Author:      "Argus Cyclist",
+		},
+		IsTest:        true,
+		TestType:      "vo2max5",
+		Segments:      segments,
+		TotalDuration: 2400,
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces native, built-in physiological assessments to the Argus Cyclist platform, eliminating the need for users to import third-party `.zwo` files to establish their baseline metrics. It also introduces a "Data-Only Mode" HUD that hides 3D rendering distractions during tests, focusing entirely on telemetry.

Closes #169 

## Key Changes

### Backend (Go Engine)
* **In-Memory Workout Factory:** Created `GetBuiltInAssessments()` returning standard protocols:
  * **Ramp Test:** 1-minute steps scaling by 6% until exhaustion (Calculates FTP at 75% of best 1-min power).
  * **20-Minute FTP Test:** Hunter Allen protocol with a 20-min `FreeRide` block (Calculates FTP at 95% of 20-min average).
  * **5-Minute VO2Max (MAP):** 5-min all-out effort (Calculates FTP at 80% of 5-min average).
* **Dynamic ERG/SIM Switching:** The physics engine now recognizes a `FreeRide` flag within workout segments, automatically releasing the smart trainer from ERG mode to SIM mode (1% grade) so the rider can control power via gears.
* **Auto-Calculation:** `FinishSession` now calculates the `NewFTP` and `NewMaxHR` automatically using the Mean Maximal Power (MMP) algorithm.

### Frontend (UI/UX)
* **Assessments Modal:** Added a new dedicated button and glassmorphism modal to select tests.
* **Data-Only Mode:** When an assessment is loaded, the application dynamically hides the 3D map, elevation footer, and left sidebar, seamlessly switching to the centralized Dashboard view for distraction-free execution.
* **Dynamic Targets:** The UI now displays "FREE RIDE - CONTROL YOUR GEARS" in blue during testing blocks instead of a fixed target wattage.
* **Profile Auto-Update:** Added a post-workout prompt that alerts the user of their new FTP/Max HR and offers to save it directly to their local profile database.

## How to Test
1. Launch the application (`wails dev`) and select a profile.
2. Ensure a Smart Trainer (or the Virtual Simulator) is connected.
3. Click the new **Assessments** button in the top header.
4. Select any test (e.g., *20-Min FTP Test*).
5. Verify that the 3D Map disappears and the central Dashboard is displayed.
6. Click **START RIDE**.
7. Skip to the end of the test (or simulate data) to trigger the `FinishSession` logic.
8. Verify that the post-workout prompt appears suggesting the newly calculated FTP.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have updated the `SessionSummary` and `WorkoutState` structs.
- [x] Wails bindings have been regenerated (`wails generate module`).