### PR TITLE
feat: verify baseline FTP before starting physiological assessments

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -830,6 +830,23 @@
         </div>
     </div>
 
+    <div id="ftpAssessmentConfirmModal" class="modal-overlay hidden">
+        <div class="modal-content-small" style="width: 540px; max-width: 90%;">
+            <div class="modal-header" style="display:flex; justify-content: space-between; align-items: center;">
+                <h2 style="margin: 0; color: var(--zone-4);">Confirm Baseline FTP</h2>
+                <button class="close-btn"
+                    style="background:none; border:none; color:#fff; font-size:24px; cursor:pointer;"
+                    onclick="window.closeAssessmentFTPConfirmModal()">×</button>
+            </div>
+            <p id="ftpAssessmentConfirmMessage"
+                style="color: var(--text-muted); margin-top: 14px; font-size: 14px; line-height: 1.6;"></p>
+            <div class="modal-actions centered" style="margin-top: 24px; gap: 12px; justify-content: flex-end;">
+                <button id="btnEditAssessmentFTP" class="btn-secondary">Edit FTP</button>
+                <button id="btnProceedAssessmentFTP" class="btn-primary">Proceed</button>
+            </div>
+        </div>
+    </div>
+
     <footer>
         <div class="elevation-header"><span>Elevation Profile</span><span id="elevationCurrent"></span></div>
         <div class="elevation-graph-container">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -153,6 +153,43 @@ if (Capacitor.isNativePlatform()) {
     document.getElementById('btnConnHR').classList.remove('hidden');
 }
 
+let pendingAssessmentTest = null;
+
+function closeAssessmentFTPConfirmModal() {
+    const modal = document.getElementById('ftpAssessmentConfirmModal');
+    if (!modal) return;
+
+    modal.classList.remove('active');
+    modal.classList.add('hidden');
+    pendingAssessmentTest = null;
+}
+
+async function openAssessmentFTPConfirmModal(test) {
+    const profile = await window.go.main.App.GetUserProfile();
+    const ftp = profile?.ftp || 200;
+
+    pendingAssessmentTest = test;
+
+    const message = document.getElementById('ftpAssessmentConfirmMessage');
+    const proceedButton = document.getElementById('btnProceedAssessmentFTP');
+
+    if (message) {
+        message.textContent = `You are about to start an FTP Assessment. Your current saved FTP is ${ftp} W. The test warm-up and scaling will be based on this value.`;
+    }
+
+    if (proceedButton) {
+        proceedButton.textContent = `Proceed with ${ftp} W`;
+    }
+
+    const modal = document.getElementById('ftpAssessmentConfirmModal');
+    if (!modal) return;
+
+    modal.classList.remove('hidden');
+    modal.classList.add('active');
+}
+
+window.closeAssessmentFTPConfirmModal = closeAssessmentFTPConfirmModal;
+
 window.closeWorkout = async () => {
     if (confirm("Stop the structured workout and return to Free Ride?")) {
         if (typeof workoutCtrl !== 'undefined') workoutCtrl.hide();
@@ -204,6 +241,22 @@ document.getElementById('btnCloseSettings').addEventListener('click', () => ui.t
 document.getElementById('btnOpenSettings').addEventListener('click', async () => {
     ui.toggleSettings(true);
     await window.checkStravaStatus();
+});
+
+document.getElementById('btnEditAssessmentFTP').addEventListener('click', async () => {
+    closeAssessmentFTPConfirmModal();
+    await ui.openProfileSettings();
+    await window.checkStravaStatus();
+});
+
+document.getElementById('btnProceedAssessmentFTP').addEventListener('click', async () => {
+    if (!pendingAssessmentTest) return;
+
+    const selectedTest = pendingAssessmentTest;
+    closeAssessmentFTPConfirmModal();
+
+    await window.go.main.App.SetBuiltInWorkout(selectedTest.test_type);
+    window.ui.els.btnAction.classList.remove('hidden');
 });
 
 document.getElementById('btnToggleView').addEventListener('click', () => {
@@ -864,8 +917,7 @@ document.getElementById('btnFitnessTests').addEventListener('click', async () =>
                 modal.classList.remove('active');
                 modal.classList.add('hidden');
 
-                await window.go.main.App.SetBuiltInWorkout(test.test_type);
-                window.ui.els.btnAction.classList.remove('hidden');
+                await openAssessmentFTPConfirmModal(test);
             };
             list.appendChild(btn);
         });

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -653,6 +653,29 @@ export class UIManager {
     }
 
     /**
+     * Opens the settings modal on the Profile tab and focuses the FTP field.
+     */
+    async openProfileSettings() {
+        this.toggleSettings(true);
+
+        document.querySelectorAll('.tab-pane').forEach((el) => el.classList.remove('active'));
+        document.querySelectorAll('.tab-btn').forEach((el) => el.classList.remove('active'));
+
+        const profileTab = document.getElementById('tab-profile');
+        const profileTabButton = document.querySelector('.tab-btn[onclick*="tab-profile"]');
+
+        if (profileTab) profileTab.classList.add('active');
+        if (profileTabButton) profileTabButton.classList.add('active');
+
+        await this.loadUserProfile();
+
+        if (this.els.inputFTP) {
+            this.els.inputFTP.focus();
+            this.els.inputFTP.select();
+        }
+    }
+
+    /**
      * Update UI based on recording state.
      * @param {'RECORDING' | 'PAUSED' | 'IDLE'} state
      */


### PR DESCRIPTION
## Description
Structured assessments (like the Ramp Test or 20-Min FTP Test) scale their warm-up and target blocks based on the user's currently saved FTP. To prevent a test from starting too hard or too easy due to outdated profile data, this PR introduces a verification step. The system now confirms the baseline FTP with the user before the test begins, ensuring accurate scaling.

## Changes Made
* **UI/UX:** Added the `ftpAssessmentConfirmModal` which intercepts the test selection from the "Physiological Assessments" menu.
* **Data Fetching:** The modal dynamically fetches and displays the user's currently saved FTP.
* **Actions:** 
  * Implemented the **"Proceed with [X] W"** button, which dismisses the modal, loads the workout, and prepares the Data-Only HUD.
  * Implemented the **"Edit FTP"** button, which dismisses the modal and opens the Profile Settings tab so the user can adjust their baseline.
* **Logic Preservation:** Kept the post-test auto-calculation prompts fully intact to seamlessly handle the test results once finished.

## Acceptance Criteria
- [x] Intercept the event when a user selects a test from the "Physiological Assessments" modal.
- [x] Fetch the current user's saved FTP from the local database.
- [x] Display a confirmation prompt/modal stating: "You are about to start an FTP Assessment. Your current saved FTP is [X] W. The test warm-up and scaling will be based on this value."
- [x] Provide two action buttons: "Proceed with [X] W" and "Edit FTP".
- [x] Ensure the post-test auto-calculation prompt remains intact.

Closes #177 