### PR TITLE
feat(history): add post-ride sharing menu with PDF and PNG export

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -959,9 +959,43 @@
                 <h2 id="detail-route-name" style="margin: 0;">Training Name</h2>
 
                 <div style="display: flex; gap: 10px; align-items: center; margin-left: auto;">
-                    <button class="btn-secondary" onclick="window.ui.exportPDF()"
-                        style="padding: 6px 12px; font-size: 0.85rem; border-color: #38bdf8;">Export PDF
-                        Report</button>
+                    <div class="share-dropdown-container">
+                        <button class="btn-secondary" onclick="window.ui.toggleShareMenu(event)"
+                            style="padding: 6px 12px; font-size: 0.85rem; border-color: #38bdf8; display: flex; align-items: center; gap: 6px;">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="18" cy="5" r="3"></circle>
+                                <circle cx="6" cy="12" r="3"></circle>
+                                <circle cx="18" cy="19" r="3"></circle>
+                                <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+                                <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+                            </svg>
+                            Share / Export
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                        <div id="share-dropdown-menu" class="share-dropdown-menu hidden">
+                            <button onclick="window.ui.exportPDF()">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                                    <polyline points="14 2 14 8 20 8"></polyline>
+                                    <line x1="12" y1="18" x2="12" y2="12"></line>
+                                    <line x1="9" y1="15" x2="12" y2="12"></line>
+                                    <line x1="15" y1="15" x2="12" y2="12"></line>
+                                </svg>
+                                Export PDF Report
+                            </button>
+                            <button onclick="window.ui.exportPNG()">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                                    <circle cx="8.5" cy="8.5" r="1.5"></circle>
+                                    <polyline points="21 15 16 10 5 21"></polyline>
+                                </svg>
+                                Export as PNG Image
+                            </button>
+                            
+                        </div>
+                    </div>
                     <button class="close-btn" onclick="ui.closeDetailModal()"
                         style="margin-left: 15px; background: none; border: none; color: #fff; font-size: 24px; cursor: pointer;">×</button>
                 </div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor/core": "^8.2.0",
         "@capacitor/ios": "^8.2.0",
         "echarts": "^6.0.0",
+        "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.17.0"
       },
@@ -1449,7 +1450,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "optional": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -2091,7 +2091,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
       "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
       }
@@ -3496,7 +3495,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "optional": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
@@ -5949,7 +5947,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
       "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
       }
@@ -6179,7 +6176,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }
@@ -7553,8 +7549,7 @@
     "base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "optional": true
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -8017,7 +8012,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
       "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "optional": true,
       "requires": {
         "utrie": "^1.0.2"
       }
@@ -8947,7 +8941,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "optional": true,
       "requires": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
@@ -10655,7 +10648,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
       "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "optional": true,
       "requires": {
         "utrie": "^1.0.2"
       }
@@ -10807,7 +10799,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "optional": true,
       "requires": {
         "base64-arraybuffer": "^1.0.2"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@capacitor/core": "^8.2.0",
     "@capacitor/ios": "^8.2.0",
     "echarts": "^6.0.0",
+    "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.17.0"
   }

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -19,6 +19,7 @@
 import { CONFIG } from '../config.js';
 import * as echarts from 'echarts';
 import { jsPDF } from 'jspdf';
+import html2canvas from 'html2canvas';
 
 /**
  * UIManager
@@ -2139,6 +2140,63 @@ export class UIManager {
         } catch (error) {
             console.error("Export PDF Error:", error);
             alert("Failed to export PDF: " + error);
+        }
+    }
+
+    toggleShareMenu(event) {
+        event.stopPropagation();
+        const menu = document.getElementById('share-dropdown-menu');
+        if (menu.classList.contains('hidden')) {
+            menu.classList.remove('hidden');
+            document.addEventListener('click', this._closeShareMenuHandler);
+        } else {
+            menu.classList.add('hidden');
+            document.removeEventListener('click', this._closeShareMenuHandler);
+        }
+    }
+
+    _closeShareMenuHandler = (event) => {
+        const menu = document.getElementById('share-dropdown-menu');
+        const container = document.querySelector('.share-dropdown-container');
+        if (container && !container.contains(event.target)) {
+            menu.classList.add('hidden');
+            document.removeEventListener('click', this._closeShareMenuHandler);
+        }
+    };
+
+    async exportPNG() {
+        if (!this.currentViewedActivity) return;
+
+        const menu = document.getElementById('share-dropdown-menu');
+        menu.classList.add('hidden');
+        document.removeEventListener('click', this._closeShareMenuHandler);
+
+        this.showToast("Generating PNG Image...", 2000);
+
+        try {
+            const modal = document.querySelector('.modern-detail-modal');
+            if (!modal) {
+                throw new Error("Modal not found");
+            }
+
+            const canvas = await html2canvas(modal, {
+                scale: 2,
+                backgroundColor: '#1e293b',
+                logging: false,
+                useCORS: true
+            });
+
+            const link = document.createElement('a');
+            const act = this.currentViewedActivity;
+            const date = new Date(act.created_at).toLocaleDateString().replace(/[\/\s]/g, '_');
+            link.download = `Argus_Ride_${date}.png`;
+            link.href = canvas.toDataURL('image/png');
+            link.click();
+
+            this.showToast("PNG Image Exported Successfully!", 3000);
+        } catch (error) {
+            console.error("Export PNG Error:", error);
+            this.showToast("Failed to export PNG: " + error.message, 4000);
         }
     }
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3507,3 +3507,60 @@ body.challenge-mode-active .main-viewport {
 .stat-box-small {
     overflow: visible !important;
 }
+
+/* ============================
+   SHARE/EXPORT DROPDOWN
+   ============================ */
+.share-dropdown-container {
+    position: relative;
+}
+
+.share-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    min-width: 220px;
+    background: #1e293b;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 10px;
+    padding: 6px;
+    z-index: 1000;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+    animation: dropdownFadeIn 0.2s ease;
+}
+
+@keyframes dropdownFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.share-dropdown-menu button {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 14px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: #e2e8f0;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-align: left;
+}
+
+.share-dropdown-menu button:hover {
+    background: rgba(56, 189, 248, 0.15);
+    color: #38bdf8;
+}
+
+.share-dropdown-menu button svg {
+    flex-shrink: 0;
+}


### PR DESCRIPTION
## Description 
Implemented a comprehensive "Share/Export" dropdown menu in the Activity Details modal to enhance user engagement and data portability.

## Changes Made
- Replaced the standalone "Export PDF Report" button with a "Share / Export" dropdown containing:
 - PDF Export: Maintains existing detailed landscape PDF report functionality
 - PNG Export: New option to export activity summary as high-resolution image using html2canvas 
- Added loading toast indicators for all export operations 
- Implemented dropdown auto-close when clicking outside

Closes #176 