### PR TITLE
feat: increase Time Trial grace period to 10s

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -577,7 +577,7 @@
                     </div>
                     <div class="challenge-side-metric" id="challengeGraceMetric">
                         <span class="challenge-chip-label">Grace Window</span>
-                        <strong id="challengeGraceValue">5.0s</strong>
+                        <strong id="challengeGraceValue">10s</strong>
                     </div>
                 </div>
             </div>

--- a/frontend/src/modules/ChallengeController.js
+++ b/frontend/src/modules/ChallengeController.js
@@ -494,7 +494,7 @@ export class ChallengeController {
             targetPower,
             tolerance: targetPower * 0.05,
             score: 0,
-            graceRemaining: 5,
+            graceRemaining: 10,
             threshold: 5,
             history: new Array(180).fill(targetPower),
             isOutOfZone: false
@@ -563,7 +563,7 @@ export class ChallengeController {
         if (this.activeChallenge.type === 'timeTrial') {
             this.els.secondaryValue.textContent = '0 pts';
             this.els.statusLabel.textContent = `Target locked at ${this.activeChallenge.targetPower} W`;
-            this.els.graceValue.textContent = '5.0s';
+            this.els.graceValue.textContent = '10s';
         }
         this.renderInlineLeaderboard();
     }
@@ -642,7 +642,7 @@ export class ChallengeController {
 
         if (inZone) {
             challenge.isOutOfZone = false;
-            challenge.graceRemaining = 5;
+            challenge.graceRemaining = 10;
             challenge.score += Math.pow(challenge.targetPower, 1.5) * dt;
             this.els.statusLabel.textContent = 'Inside target zone';
         } else {


### PR DESCRIPTION
## Description
This PR increases the out-of-zone grace period in the Time Trial challenge from 5 seconds to 10 seconds. 

Fixes #195 

## Changes Made
- Modified `frontend/src/modules/ChallengeController.js`:
  - Changed `graceRemaining: 5` to `10` in the challenge configuration (`launchTimeTrial`).
  - Updated the initial UI string to `10.0s` (`updateChallengeChrome`).
  - Adjusted the reset logic to return `graceRemaining` to `10` when the rider successfully re-enters the target power zone (`updateTimeTrial`).

## Motivation
A 5-second window is often too brief for beginners to stabilize their cadence and power output, resulting in frustrating challenge failures. Doubling this window to 10 seconds provides a more forgiving and accessible experience for non-cyclists, allowing them enough time to react and adjust.

## Testing Instructions
1. Launch the application and enter the Event Hub.
2. Start a "Time Trial" challenge.
3. Stop pedaling or go outside the target power zone.
4. Verify that the grace timer starts at 10.0s and counts down.
5. Return to the target power zone and verify that the timer resets back to 10.0s.