### PR TITLE
feat: persist event leaderboard to dedicated SQLite DB (#192)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ routes/
 argus_data.db
 argus_master.db
 users_data
+events_ranking.db
 
 frontend/package.json.md5
 

--- a/app.go
+++ b/app.go
@@ -1772,3 +1772,33 @@ func (a *App) SetBuiltInWorkout(testType string) string {
 	}
 	return "Not found"
 }
+
+// ==========================
+// EVENT LEADERBOARD BINDINGS
+// ==========================
+
+// SaveEventResult is called by the frontend to persist a challenge result.
+func (a *App) SaveEventResult(riderName string, mode string, score float64, status string) error {
+	record := domain.EventRecord{
+		RiderName: riderName,
+		EventMode: mode,
+		Score:     score,
+		Status:    status,
+		CreatedAt: time.Now(),
+	}
+	return a.storageService.SaveEventRecord(record)
+}
+
+// GetEventLeaderboard fetches the top N records for a specific mode.
+func (a *App) GetEventLeaderboard(mode string) []domain.EventRecord {
+	records, err := a.storageService.GetTopEventRecords(mode, 10)
+	if err != nil {
+		return []domain.EventRecord{}
+	}
+	return records
+}
+
+// ResetEventLeaderboard clears the rankings for a mode (or "all").
+func (a *App) ResetEventLeaderboard(mode string) error {
+	return a.storageService.ResetEventLeaderboard(mode)
+}

--- a/frontend/src/modules/ChallengeController.js
+++ b/frontend/src/modules/ChallengeController.js
@@ -97,6 +97,8 @@ export class ChallengeController {
         this.lastFrameTime = 0;
         this.tunnelParticles = Array.from({ length: 140 }, () => this.makeTunnelParticle(true));
 
+        window.challengeController = this;
+
         this.bindEvents();
         this.resizeCanvases();
 
@@ -166,7 +168,8 @@ export class ChallengeController {
         this.closeModal(this.els.resultModal);
     }
 
-    openLeaderboard() {
+    async openLeaderboard() {
+        await this.fetchLeaderboardsFromDB();
         this.renderLeaderboardModal();
         this.openModal(this.els.leaderboardModal);
     }
@@ -190,6 +193,25 @@ export class ChallengeController {
             return '';
         }
         return name;
+    }
+
+    async fetchLeaderboardsFromDB() {
+        if (!window.go?.main?.App?.GetEventLeaderboard) return;
+
+        for (const type of Object.keys(this.modeMeta)) {
+            try {
+                const records = await window.go.main.App.GetEventLeaderboard(type);
+                this.leaderboards[type] = (records || []).map(r => ({
+                    rider: r.rider_name,
+                    value: r.score,
+                    status: r.status,
+                    createdAt: new Date(r.created_at).getTime()
+                }));
+            } catch (e) {
+                console.error(`Failed to fetch leaderboard for ${type}:`, e);
+                this.leaderboards[type] = [];
+            }
+        }
     }
 
     async hasTrainerConnection() {
@@ -1014,8 +1036,9 @@ export class ChallengeController {
         return this.activeChallenge.score || 0;
     }
 
-    saveResult(type, rider, value, status) {
+    async saveResult(type, rider, value, status) {
         if (!rider || value <= 0) return;
+
         this.leaderboards[type].push({
             rider,
             value,
@@ -1023,6 +1046,24 @@ export class ChallengeController {
             createdAt: Date.now()
         });
         this.leaderboards[type].sort((a, b) => b.value - a.value);
+
+        if (window.go?.main?.App?.SaveEventResult) {
+            try {
+                await window.go.main.App.SaveEventResult(rider, type, value, status);
+            } catch (e) {
+                console.error("Failed to save event result:", e);
+            }
+        }
+    }
+
+    async resetLeaderboard(type) {
+        if (confirm(`Are you sure you want to clear the ranking for ${type === 'all' ? 'ALL events' : this.modeMeta[type].title}? This cannot be undone.`)) {
+            if (window.go?.main?.App?.ResetEventLeaderboard) {
+                await window.go.main.App.ResetEventLeaderboard(type);
+                await this.fetchLeaderboardsFromDB();
+                this.renderLeaderboardModal();
+            }
+        }
     }
 
     renderLeaderboardModal() {
@@ -1033,7 +1074,15 @@ export class ChallengeController {
 
             return `
                 <section class="leaderboard-category-card">
-                    <h3>${meta.fullTitle}</h3>
+                    <div style="display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 10px; margin-bottom: 15px;">
+                        <h3 style="margin: 0;">${meta.fullTitle}</h3>
+                        <button onclick="window.challengeController.resetLeaderboard('${type}')" class="icon-minimal-danger" title="Clear Ranking" style="display: flex; align-items: center; background: none; border: none; color: #e74c3c; cursor: pointer; font-size: 0.85rem; font-weight: bold; transition: opacity 0.2s;" onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 6px;">
+                                <path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
+                            </svg>
+                            Reset
+                        </button>
+                    </div>
                     <div class="leaderboard-podium">
                         ${podium.map((entry, index) => `
                             <div class="leaderboard-podium-entry ${entry ? `is-${['first', 'second', 'third'][index]}` : ''}">

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -47,6 +47,8 @@ export function GetDeviceConnectionState():Promise<Record<string, any>>;
 
 export function GetElevationProfile():Promise<Array<number>>;
 
+export function GetEventLeaderboard(arg1:string):Promise<Array<domain.EventRecord>>;
+
 export function GetFitnessTests():Promise<Array<domain.ActiveWorkout>>;
 
 export function GetLocalAccounts():Promise<Array<storage.ProfileSummary>>;
@@ -74,6 +76,10 @@ export function OpenFileFolder(arg1:string):Promise<void>;
 export function RepeatWorkout():Promise<string>;
 
 export function ResetAppState():Promise<void>;
+
+export function ResetEventLeaderboard(arg1:string):Promise<void>;
+
+export function SaveEventResult(arg1:string,arg2:string,arg3:number,arg4:string):Promise<void>;
 
 export function SaveGeneratedGPX(arg1:string,arg2:Array<main.ExportPoint>):Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -86,6 +86,10 @@ export function GetElevationProfile() {
   return window['go']['main']['App']['GetElevationProfile']();
 }
 
+export function GetEventLeaderboard(arg1) {
+  return window['go']['main']['App']['GetEventLeaderboard'](arg1);
+}
+
 export function GetFitnessTests() {
   return window['go']['main']['App']['GetFitnessTests']();
 }
@@ -140,6 +144,14 @@ export function RepeatWorkout() {
 
 export function ResetAppState() {
   return window['go']['main']['App']['ResetAppState']();
+}
+
+export function ResetEventLeaderboard(arg1) {
+  return window['go']['main']['App']['ResetEventLeaderboard'](arg1);
+}
+
+export function SaveEventResult(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['App']['SaveEventResult'](arg1, arg2, arg3, arg4);
 }
 
 export function SaveGeneratedGPX(arg1, arg2) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -247,6 +247,47 @@ export namespace domain {
 	        this.address = source["address"];
 	    }
 	}
+	export class EventRecord {
+	    id: number;
+	    rider_name: string;
+	    event_mode: string;
+	    score: number;
+	    status: string;
+	    // Go type: time
+	    created_at: any;
+	
+	    static createFrom(source: any = {}) {
+	        return new EventRecord(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.rider_name = source["rider_name"];
+	        this.event_mode = source["event_mode"];
+	        this.score = source["score"];
+	        this.status = source["status"];
+	        this.created_at = this.convertValues(source["created_at"], null);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class RoutePoint {
 	    lat: number;
 	    lon: number;

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -108,8 +108,19 @@ type Activity struct {
 	TimeInHRZones     map[string]int `json:"time_in_hr_zones" gorm:"serializer:json"`
 	UploadedToStrava  bool           `json:"uploaded_to_strava"`
 	PeakHR            int            `json:"peak_hr"`
-    HRR1              int            `json:"hrr_1"`
-    HRR2              int            `json:"hrr_2"`
+	HRR1              int            `json:"hrr_1"`
+	HRR2              int            `json:"hrr_2"`
+}
+
+// EventRecord represents a leaderboard entry for Event Mode.
+// Kept separate from the standard Activity model to maintain isolation.
+type EventRecord struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	RiderName string    `json:"rider_name"`
+	EventMode string    `json:"event_mode"` // "sprint", "kom", "timeTrial"
+	Score     float64   `json:"score"`      // Watts, Distance, or Points
+	Status    string    `json:"status"`     // "success", "failed"
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // BLEDevice represents a Bluetooth device found during the scan.

--- a/internal/service/storage/service.go
+++ b/internal/service/storage/service.go
@@ -56,6 +56,7 @@ type ProfileSummary struct {
 type Service struct {
 	masterDB *gorm.DB
 	userDB   *gorm.DB
+	eventDB  *gorm.DB
 }
 
 // NewService initializes the master database connection.
@@ -73,7 +74,15 @@ func NewService() *Service {
 		fmt.Println("Error migrating master DB:", err)
 	}
 
-	return &Service{masterDB: db, userDB: nil}
+	eventDbPath := "events_ranking.db"
+	eventDB, err := gorm.Open(sqlite.Open(eventDbPath), &gorm.Config{})
+	if err != nil {
+		fmt.Println("Error opening event DB:", err)
+	} else {
+		eventDB.AutoMigrate(&domain.EventRecord{})
+	}
+
+	return &Service{masterDB: db, userDB: nil, eventDB: eventDB}
 }
 
 // ====================
@@ -374,4 +383,39 @@ func (s *Service) UpdateActivityStatus(id uint, uploaded bool) error {
 		return fmt.Errorf("no user database loaded")
 	}
 	return s.userDB.Model(&domain.Activity{}).Where("id = ?", id).Update("uploaded_to_strava", uploaded).Error
+}
+
+// =================
+// EVENT LEADERBOARD
+// =================
+
+func (s *Service) SaveEventRecord(record domain.EventRecord) error {
+	if s.eventDB == nil {
+		return fmt.Errorf("Event database not initialized")
+	}
+	return s.eventDB.Create(&record).Error
+}
+
+func (s *Service) GetTopEventRecords(mode string, limit int) ([]domain.EventRecord, error) {
+	var records []domain.EventRecord
+	if s.eventDB == nil {
+		return records, fmt.Errorf("Event database not initialized")
+	}
+
+	err := s.eventDB.Where("event_mode = ? AND status = ?", mode, "success").
+		Order("score desc").
+		Limit(limit).
+		Find(&records).Error
+
+	return records, err
+}
+
+func (s *Service) ResetEventLeaderboard(mode string) error {
+	if s.eventDB == nil {
+		return fmt.Errorf("Event database not initialized")
+	}
+	if mode == "all" {
+		return s.eventDB.Exec("DELETE FROM event_records").Error
+	}
+	return s.eventDB.Where("event_mode = ?", mode).Delete(&domain.EventRecord{}).Error
 }


### PR DESCRIPTION
## Description
This PR resolves issue #192. Previously, the Event Mode leaderboard (Sprint, KOM, Time Trial) was kept entirely in-memory and wiped clean upon restarting the application. This update introduces a dedicated SQLite database (`events_ranking.db`) to persist these high scores permanently while ensuring they remain strictly isolated from the main user profiles and activity history.

## Changes Made
* **Backend (Go):**
  * Created the `EventRecord` model to represent leaderboard entries.
  * Initialized a secondary database connection (`events_ranking.db`) in the `storage.Service`.
  * Implemented `SaveEventRecord`, `GetTopEventRecords`, and `ResetEventLeaderboard` methods.
  * Bound the new methods to the Wails frontend in `app.go`.
* **Frontend (JS/UI):**
  * Refactored `ChallengeController.js` to fetch real data from the backend when opening the leaderboard modal.
  * Replaced the volatile in-memory saving with calls to `window.go.main.App.SaveEventResult`.
  * Added a "Reset" button (with a trash icon) to the UI, allowing event organizers to clear rankings per category.
  * Fixed JavaScript context scoping (`window.challengeController = this`) to allow inline HTML buttons to trigger the reset method.
  * Added null-safety checks (`records || []`) to handle empty database returns gracefully and prevent mapping errors.

## How to Test
1. Launch the application and enter **Event Mode**.
2. Complete a Sprint, KOM, or Time Trial challenge with a valid rider name.
3. Check the Leaderboard; your result should be saved and displayed correctly.
4. Close the application and reopen it. Check the Leaderboard again to ensure the result persists.
5. Click the "Reset" button on any category, confirm the prompt, and verify that the UI updates immediately to "No attempts yet".

Closes #192