### PR TITLE
docs: introduce project knowledge base and technical specifications

### DIFF
--- a/docs/01-academico/justificativa.md
+++ b/docs/01-academico/justificativa.md
@@ -1,0 +1,17 @@
+# Justificativa
+
+O desenvolvimento do sistema **Argus Cyclist** justifica-se por sua alta relevância nas dimensões acadêmica, tecnológica e social, configurando-se como um projeto de Engenharia de Software capaz de resolver problemas reais do ecossistema esportivo.
+
+**1. Relevância Tecnológica e Inovação:**
+Do ponto de vista da Ciência da Computação, o projeto propõe um desafio arquitetural complexo: o processamento concorrente e em tempo real de sinais de hardware (sensores BLE). A adoção do framework **Wails** e a linguagem **Go (Golang)** no backend justificam-se pela necessidade de altíssimo desempenho, segurança de memória e concorrência nativa (goroutines) no tratamento dos protocolos GATT/BLE, garantindo uma latência imperceptível. O encapsulamento dessa complexidade por trás de uma interface web reativa (Vite) e a portabilidade via Capacitor (Mobile) demonstram a aplicação do estado da arte em desenvolvimento de software multiplataforma.
+
+**2. Impacto Social e Fomento ao Esporte:**
+Ao propor uma arquitetura limpa e independente de assinaturas onerosas em dólar, o Argus Cyclist democratiza o treinamento esportivo de alto rendimento. Ele permite que ciclistas locais utilizem rolos de treino *smart* e medidores de potência com um software de interface amigável, promovendo a saúde e a inclusão digital no esporte.
+
+**3. Soberania Tecnológica e Padronização:**
+A criação de uma solução nacional reduz a dependência de caixas-pretas proprietárias. O projeto atua ativamente na implementação e manipulação de padrões globais de engenharia esportiva — como a decodificação do protocolo FTMS, a modelagem de arquivos binários `.FIT` (Flexible and Interoperable Data Transfer) e a integração segura via OAuth 2.0 com APIs globais (Strava).
+
+**4. Relevância Acadêmica (Contexto TCC):**
+Para o escopo de um Trabalho de Conclusão de Curso, o projeto transcende o desenvolvimento de um simples sistema de informação. Ele exige conhecimentos avançados em comunicação de rede de baixo nível, engenharia de software modular, matemática aplicada (motores de simulação física baseada em dados `.gpx` e arrasto aerodinâmico) e experiência de usuário (UX). Consequentemente, resulta em um artefato robusto, perfeitamente elegível para o registro de software junto ao INPI.
+
+Para o curso de Ciência da Computação/Engenharia da UERN, o projeto serve como um registro de software robusto que abrange desde o tratamento de sinais de sensores até o processamento de dados em nuvem.

--- a/docs/01-academico/metodologia.md
+++ b/docs/01-academico/metodologia.md
@@ -1,0 +1,37 @@
+# Metodologia
+
+Para atingir os objetivos propostos de forma estruturada e científica, este trabalho adota uma **pesquisa de natureza aplicada**, com abordagem quali-quantitativa, focada no desenvolvimento tecnológico e experimental. O ciclo de vida do projeto baseia-se em um modelo de **desenvolvimento iterativo e incremental**, inspirado nas práticas das metodologias ágeis de Engenharia de Software.
+
+As etapas metodológicas adotadas dividem-se em quatro fases principais:
+
+## 1. Levantamento e Especificação
+
+A primeira fase constituiu na análise de mercado das plataformas de *cycling e-sports* (Zwift, Rouvy, Mywhoosh) para identificar as lacunas de performance e acessibilidade. A partir disso, foram mapeados os protocolos de comunicação essenciais:
+
+* **Especificação BLE:** Mapeamento dos UUIDs padrão para *Heart Rate* (0x180D), *Cycling Power* (0x1818) e *Fitness Machine* (0x1826).
+* **Estrutura de Dados:** Estudo do protocolo `.FIT` da Garmin para armazenamento de sessões.
+* **API de Terceiros:** Documentação do fluxo OAuth 2.0 e endpoints RESTful do Strava.
+
+## 2. Definição Arquitetural
+
+A arquitetura do Argus Cyclist foi projetada visando máxima modularidade e separação de responsabilidades (*Clean Architecture*). Foram selecionadas as seguintes tecnologias:
+
+* **Backend (Core System):** Desenvolvido em **Go**, responsável pelo processamento assíncrono, interface com o subsistema Bluetooth do Sistema Operacional, motor de simulação (parse de arquivos GPX) e serialização de dados binários.
+* **Bridge Multiplataforma:** O framework **Wails** foi adotado para encapsular a aplicação em um binário executável para Desktop, provendo um canal de comunicação IPC (Inter-Process Communication) rápido entre o Go e a interface gráfica.
+* **Frontend:** Implementado com **JavaScript/Vite**, garantindo uma interface rica, responsiva e leve, adaptável a diferentes resoluções.
+* **Mobile:** Utilização do **Capacitor** para injetar a interface web nativamente em dispositivos móveis, reutilizando a base de código do frontend.
+
+## 3. Implementação e Codificação
+
+O desenvolvimento foi segmentado em módulos autônomos:
+
+1. **Módulo de Hardware (`internal/service/ble`):** Implementação de clientes genéricos e *mocks* para varredura e conexão com sensores GATT.
+2. **Módulo de Simulação (`internal/service/sim`):** Desenvolvimento do motor físico que calcula velocidade e potência simulada com base na altimetria de arquivos GPX.
+3. **Módulo de Armazenamento e Exportação (`internal/service/fit` e `strava`):** Geração local e criptografada de tokens de sessão, e rotinas de upload *multipart* para a nuvem.
+
+## 4. Testes e Validação Experimental
+
+A validação do software não se restringe a testes unitários, envolvendo testes de integração em ambiente real:
+
+* **Benchmarking de Hardware:** Conexão simultânea de sensores reais (cintas cardíacas e rolos *smart*) para atestar a estabilidade e medir a latência da telemetria (requisitada para operar em $< 100\text{ms}$).
+* **Validação de Conformidade:** Submissão dos arquivos `.fit` gerados pelo Argus Cyclist a plataformas de análise (Strava e Garmin Connect) para comprovar a exatidão estrutural, garantindo que o software opera nos padrões da indústria.

--- a/docs/01-academico/problematica.md
+++ b/docs/01-academico/problematica.md
@@ -1,0 +1,9 @@
+# Problemática
+
+O cenário do ciclismo virtual atual apresenta barreiras que transcendem o custo financeiro:
+
+1. **Monetização de Métricas Críticas:** Softwares líderes (Zwift, Rouvy) frequentemente restringem análises detalhadas de performance — como Zonas de Potência, TSS (Training Stress Score) e picos de curva de potência — a planos pagos. Isso priva o atleta amador de entender sua evolução fisiológica.
+2. **Dependência de Processamento em Nuvem:** A maioria das soluções calcula métricas de energia e carga de treino apenas após o upload, impedindo o feedback biomecânico imediato durante a sessão offline.
+3. **Complexidade de Hardware e Custo:** Simuladores pesados exigem GPUs potentes, ignorando que o foco do ciclista de alta performance é, muitas vezes, a telemetria exata e não a renderização gráfica.
+
+O **Argus Cyclist** resolve essa lacuna ao processar localmente métricas avançadas de performance em uma plataforma leve e gratuita.

--- a/docs/02-projeto/glossario.md
+++ b/docs/02-projeto/glossario.md
@@ -1,0 +1,10 @@
+# Glossário de Termos Técnicos
+
+* **ANT+ / FE-C:** Protocolos de comunicação sem fio específicos para fitness (Fitness Equipment Control).
+* **BLE (Bluetooth Low Energy):** Tecnologia de rede sem fio de baixo consumo utilizada para comunicação com sensores esportivos.
+* **FIT File:** Formato binário interoperável criado pela Garmin, padrão para armazenamento de dados de GPS e telemetria cardíaca/potência.
+* **FTMS (Fitness Machine Service):** Protocolo padrão Bluetooth que permite que softwares controlem a resistência de equipamentos de academia e rolos de treino.
+* **GATT (Generic Attribute Profile):** Modo de comunicação do Bluetooth que define como os dados (serviços e características) são expostos por um sensor.
+* **GPX (GPS Exchange Format):** Formato XML para troca de dados de GPS (rotas, trilhas e pontos).
+* **Wails:** Framework de código aberto que permite construir aplicações desktop multiplataforma usando Go e tecnologias web modernas (Vite, Vue, React).
+* **Watts (W):** Unidade de medida de potência que representa o esforço real exercido pelo ciclista nos pedais.

--- a/docs/02-projeto/personas-e-fluxos.md
+++ b/docs/02-projeto/personas-e-fluxos.md
@@ -1,0 +1,17 @@
+# Personas e Jornada do Usuário
+
+## 1. Personas e Casos de Uso
+
+* **Carlos, o Atleta de Elite:** Ciclista competitivo e focado em alta performance. Ele utiliza o software para executar blocos rigorosos de treinamento intervalado e simular as demandas exatas de seu calendário de provas. Carlos faz o upload do arquivo GPX do percurso de sua competição alvo, como o campeonato nacional, para memorizar os pontos de ataque, subidas e sprints. Ele exige precisão na leitura de potência (Watts) e necessita da integração imediata com o Strava para que seu treinador analise a progressão do estresse de treino (TSS) a partir do arquivo `.fit`.
+
+* **Mariana, a Entusiasta Digital:** Praticante de ciclismo indoor focada em saúde, consistência e cicloturismo virtual. Ela busca uma interface limpa, intuitiva e que suporte o modo escuro (*Dark Theme*) para seus treinos noturnos. Mariana utiliza o sistema para importar rotas clássicas europeias — como as etapas de montanha na França. Como o Argus Cyclist dispensa motores gráficos 3D pesados, Mariana consegue rodar o simulador fluidamente em seu notebook de trabalho, acompanhando sua progressão pelo mapa e sentindo a resistência fiel da altimetria francesa (gradiente) diretamente em seu rolo de treino, sem a necessidade de um computador *gamer*.
+
+### 2. Fluxo Operacional (Jornada do Sistema)
+
+A jornada do usuário foi mapeada para demonstrar a interação fluida entre a interface reativa (*Frontend*) e os microsserviços de baixo nível (*Backend em Go*).
+
+1. **Descoberta e Configuração (Setup):** O usuário inicializa a aplicação. Em segundo plano, o backend em Go instila o `BLEService`, ativando a varredura (scan) das portas Bluetooth do sistema operacional para detectar periféricos compatíveis (Heart Rate, Power Meters e Smart Trainers) num raio próximo.
+2. **Pareamento e Telemetria (Handshake):** Através da interface de usuário (*UI*), o ciclista seleciona os dispositivos desejados. O sistema estabelece conexões persistentes via protocolo GATT (*Generic Attribute Profile*), assinando as características de notificação para receber dados em tempo real com latência mínima.
+3. **Sessão de Treino e Motor de Física:** Durante o esforço físico, o sistema processa os arrays de telemetria continuamente. Caso uma rota (`.gpx`) esteja carregada no `MapController`, o motor de simulação (Engine) cruza a posição GPS virtual com o gráfico de elevação (`ElevationChart`). A resistência do rolo de treino é então ajustada dinamicamente via comandos FTMS/FE-C para replicar a gravidade e o arrasto aerodinâmico.
+4. **Análise e Persistência de Dados:** Ao encerrar a sessão, o `FitService` compila o buffer de amostras temporais (BPM, Watts, Cadência, Coordenadas) e estrutura um arquivo binário padronizado (`.fit`). A interface exibe os gráficos consolidados de performance (Dashboard Pós-Treino).
+5. **Sincronização e Distribuição Social:** Com o consentimento do usuário (via *OAuth 2.0*), o módulo de rede do Go aciona a API do Strava. O sistema realiza o upload multipart do arquivo encriptado, confirmando o sucesso da publicação e integrando o treino ao ecossistema global do atleta.

--- a/docs/02-projeto/requisitos.md
+++ b/docs/02-projeto/requisitos.md
@@ -1,0 +1,18 @@
+# Especificação de Requisitos
+
+A especificação de requisitos do Argus Cyclist foi derivada da necessidade de estabilidade em tempo real e conformidade com os padrões de arquivos esportivos.
+
+## Requisitos Funcionais (RF)
+
+* **RF01 - Gestão de Sensores BLE:** O sistema deve ser capaz de realizar o escaneamento, pareamento e recepção de dados via perfis GATT de sensores de frequência cardíaca (HRM), potência (CycPWR) e cadência.
+* **RF02 - Controle de Equipamento (FTMS/FEC):** O sistema deve enviar comandos de resistência para rolos de treino inteligentes, permitindo o modo ERG ou simulação de inclinação.
+* **RF03 - Motor de Simulação GPX:** O sistema deve interpretar arquivos de rota (GPX) e calcular a velocidade virtual baseada no peso do atleta, potência gerada e inclinação do terreno.
+* **RF04 - Registro de Atividade (FIT SDK):** O sistema deve gerar arquivos binários no padrão `.fit` (Flexible and Interoperable Data Transfer), contendo todos os samples de telemetria da sessão.
+* **RF05 - Integração Strava API:** O sistema deve gerenciar a autenticação via OAuth 2.0 e realizar o upload automático de sessões finalizadas para o perfil do usuário.
+
+## Requisitos Não Funcionais (RNF)
+
+* **RNF01 - Latência de Telemetria:** O tempo entre a recepção do pacote BLE e a atualização na interface visual não deve exceder 150ms.
+* **RNF02 - Portabilidade Multiplataforma:** A base de código deve ser compilável para Windows (Wails), Linux e Android (Capacitor) sem perda de funcionalidades core.
+* **RNF03 - Estabilidade de Conexão:** O sistema deve implementar rotinas de auto-reconexão para sensores que percam sinal momentaneamente durante a sessão.
+* **RNF04 - Eficiência de Memória:** O backend em Go não deve exceder 200MB de footprint de memória durante a simulação ativa.

--- a/docs/02-projeto/visao-geral.md
+++ b/docs/02-projeto/visao-geral.md
@@ -1,0 +1,14 @@
+# Visão Geral do Produto
+
+O **Argus Cyclist** é uma plataforma de telemetria e simulação para ciclismo indoor de alto desempenho, concebida como um ecossistema modular e agnóstico a hardware. Diferente de soluções baseadas estritamente em gamificação, o Argus foca na precisão analítica e na otimização da experiência do atleta através de uma interface de baixa latência e alta fidelidade de dados.
+
+## Proposta de Valor
+
+O sistema atua como uma ponte inteligente entre o hardware esportivo (sensores de potência, frequência cardíaca e rolos de treino inteligentes) e as plataformas de análise global. Sua arquitetura híbrida (Go + Wails) garante que o software seja leve o suficiente para rodar em computadores de entrada, enquanto mantém o rigor necessário para o registro oficial de treinamentos profissionais.
+
+## Objetivos Estratégicos
+
+* **Interoperabilidade Total:** Suporte nativo aos protocolos padrão da indústria (BLE/FTMS/FE-C), garantindo que o atleta não fique preso a ecossistemas proprietários.
+* **Performance Computacional:** Utilização de processamento nativo em Go para manipulação de sinais de sensores, eliminando gargalos comuns em aplicações baseadas puramente em Electron ou Web.
+* **Sincronização Unificada:** Integração fluida com o Strava, permitindo que o ciclo de treino (da captura à análise social) ocorra em uma única interface.
+* **Simulação Física Realista:** Implementação de um motor de física que traduz gradientes de arquivos GPX em resistência real no equipamento, simulando a sensação de rodagem externa.

--- a/docs/03-tecnico/api-strava.md
+++ b/docs/03-tecnico/api-strava.md
@@ -1,0 +1,17 @@
+# Integração API Strava e Ecossistema Web
+
+O ecossistema do Argus Cyclist estende-se para a nuvem através do pacote `internal/service/strava`, que gere o ciclo de vida da integração com redes sociais de terceiros.
+
+## 1. Fluxo de Autenticação (OAuth 2.0)
+
+* **Geração de Credenciais:** O sistema redireciona o usuário para a página de consentimento do Strava solicitando o escopo `activity:write` (necessário para uploads de atividades privadas e públicas).
+* **Gestão de Tokens:** Ao receber o código de autorização, o backend troca-o por um `access_token` (de curta duração) e um `refresh_token` (longa duração). O Go encarrega-se de atualizar o token silenciosamente em *background* sempre que este expira, poupando o atleta de repetidos logins.
+
+## 2. Transmissão de Atividades
+
+Ao finalizar um treino:
+
+1. O arquivo binário `.fit` local é validado.
+2. É construída uma requisição HTTP POST *Multipart/form-data* endereçada a `https://www.strava.com/api/v3/uploads`.
+3. O Argus Cyclist transmite o arquivo com o *Data Type* definido estritamente como `fit`.
+4. O backend realiza um monitoramento ( *polling* ) do status da requisição até que o Strava processe o arquivo assincronamente e retorne o ID da atividade gerada.

--- a/docs/03-tecnico/arquitetura.md
+++ b/docs/03-tecnico/arquitetura.md
@@ -1,0 +1,19 @@
+# Arquitetura do Sistema e Engenharia de Software
+
+O **Argus Cyclist** foi projetado sob os princípios da *Clean Architecture*, promovendo uma separação estrita entre a camada de apresentação, regras de negócio e acesso a hardware/rede. A solução adota um modelo híbrido (*Desktop/Mobile*), centralizando a lógica pesada em uma linguagem de sistema.
+
+## 1. Stack Tecnológico (Core)
+
+* **Linguagem de Backend:** Go (Golang). Escolhida pela eficiência no gerenciamento de concorrência (*Goroutines*) e baixo consumo de memória, essenciais para manter conexões contínuas com múltiplos sensores BLE simultaneamente sem bloquear a *thread* principal.
+* **Bridge IPC (Inter-Process Communication):** O framework **Wails** é utilizado para exportar os métodos Go (*structs*) para o frontend, criando ligações assíncronas nativas.
+* **Frontend:** Implementado com Vite, Vue/Vanilla JS e CSS puro, focando em reatividade em tempo real (atualização de tela a 60fps) e suporte nativo a *Dark Mode*.
+* **Mobile (Cross-Platform):** Integração com **Capacitor** para encapsular a aplicação Web em binários para Android, reutilizando a interface e substituindo chamadas de hardware de desktop por APIs móveis.
+
+## 2. Topologia de Microsserviços Internos
+
+A aplicação backend está subdividida em serviços de domínio estrito:
+
+* `ble`: Camada de abstração do hardware. Responsável pelo *scan* e *handshake* GATT.
+* `sim` (Engine de Simulação): Motor físico que processa vetores de inclinação (GPX) e potência do ciclista para calcular métricas derivadas (como velocidade virtual e arrasto).
+* `fit`: Serviço de processamento de matrizes de dados e serialização. Agrega as métricas de performance minuto a minuto e as converte no padrão binário `.fit`.
+* `strava`: Cliente REST para integração com a nuvem esportiva via OAuth 2.0.

--- a/docs/03-tecnico/integracao-ble.md
+++ b/docs/03-tecnico/integracao-ble.md
@@ -1,0 +1,19 @@
+# Integração de Hardware e Protocolo BLE
+
+O módulo de comunicação com dispositivos periféricos (`internal/service/ble`) foi desenhado para lidar com a natureza assíncrona e muitas vezes instável do sinal Bluetooth em ambientes residenciais.
+
+## 1. Perfis GATT Utilizados
+
+O sistema realiza assinaturas ( *Subscriptions* / *Notifications*) nas características padrão do consórcio Bluetooth SIG:
+
+* **Heart Rate Service (`0x180D`):** Leitura de batimentos cardíacos (BPM).
+* **Cycling Power Service (`0x1818`):** Recepção de telemetria de Watts e Cadência integrada.
+* **Fitness Machine Service (FTMS - `0x1826`):** Protocolo bidirecional. Usado tanto para receber os dados do Rolo de Treino *Smart* quanto para enviar comandos de resistência (Target Power / Modo ERG ou Inclinação Simulada).
+
+### 2. Fluxo de Leitura (Concorrência)
+
+Para garantir latência $< 150\text{ms}$:
+
+1. Uma rotina de varredura identifica o MAC Address ou UUID do dispositivo.
+2. Após a conexão, o sistema aloca uma *Goroutine* dedicada para cada sensor pareado.
+3. Cada pacote hexadecimal recebido é decodificado, tratado (remoção de ruídos de sinal) e despachado para um *Channel* (canal do Go) central, que por sua vez alimenta a interface (via Wails Event Emitter) e o buffer de gravação do `.fit`.

--- a/docs/03-tecnico/modelo-dados.md
+++ b/docs/03-tecnico/modelo-dados.md
@@ -1,0 +1,22 @@
+# Modelo de Dados e Processamento de Métricas
+
+O Argus Cyclist não atua apenas como um passador de dados; ele atua como um agregador e calculador de telemetria esportiva. Os dados transitam pelo sistema em *buffers* circulares que são processados para gerar as métricas de performance do usuário.
+
+## 1. Entidades Principais (Domain Driven Design)
+
+As estruturas (*Structs*) centrais do domínio localizam-se em `internal/domain/`:
+
+* **`Workout` (Sessão):** Entidade raiz. Contém metadados essenciais (Timestamp de Início/Fim, Nome do Atleta, Dispositivos Conectados) e o resumo estatístico global.
+* **`MetricSample` (Amostra Temporal):** O menor átomo de informação. Um vetor contendo o *timestamp* da leitura, Watts, RPM (Cadência), BPM (Coração), Altitude e Velocidade instantânea. Gravado a uma frequência de 1Hz (uma vez por segundo).
+
+## 2. Motor de Métricas de Performance (`fit/metrics`)
+
+Durante e após a sessão, o motor de métricas varre o array de `MetricSamples` para calcular a performance do usuário, extraindo dados vitais para a avaliação física:
+
+* **Métricas Absolutas:** Trabalho total realizado (*Energy Expenditure*) em quilojoules (kJ), convertido para calorias estimadas.
+* **Métricas de Agregação:** Potência Média (W), Frequência Cardíaca Média e Máxima, Cadência Média.
+* **Distribuição de Esforço:** Análise de picos de potência (ex: *Sprint* de 5, 10 e 30 segundos) com base no array consolidado.
+
+## 3. Persistência e Padrão `.FIT`
+
+Para garantir que as métricas calculadas sejam aceitas universalmente, o Argus consolida os metadados e os *samples* 1Hz formatando-os rigorosamente no formato de arquivo **FIT (Flexible and Interoperable Data Transfer)**. Isso assegura interoperabilidade total com o Strava, TrainingPeaks e Garmin Connect.

--- a/docs/03-tecnico/seguranca-privacidade.md
+++ b/docs/03-tecnico/seguranca-privacidade.md
@@ -1,0 +1,15 @@
+# Segurança, Privacidade e Tratamento de Dados
+
+Sendo um software que coleta dados biométricos (frequência cardíaca) e geográficos (se rotas GPX baseadas na localização do atleta forem importadas), a arquitetura do Argus Cyclist preza pela privacidade *Privacy-by-Design*.
+
+## 1. Processamento Isolado (Edge Computing)
+
+Diferente de aplicações baseadas em nuvem, **todo o processamento biométrico e cálculo matemático de métricas ocorre localmente** na máquina do usuário (*Edge*). O Argus Cyclist não possui bancos de dados remotos próprios.
+
+## 2. Criptografia de Credenciais
+
+Os tokens do Strava (Access e Refresh) e identificadores do atleta não ficam expostos em texto claro em variáveis globais. São persistidos em arquivos locais do sistema operacional do usuário utilizando proteção de diretório e ofuscação simples.
+
+## 3. Consentimento de Compartilhamento
+
+Nenhum byte de telemetria é enviado à internet sem ação explícita. O envio (Upload) para o Strava é inteiramente opcional, funcionando na modalidade *Opt-In* ao final do treino. Caso contrário, a privacidade é absoluta e o treino reside apenas no disco rígido.

--- a/docs/03-tecnico/setup-ambiente.md
+++ b/docs/03-tecnico/setup-ambiente.md
@@ -1,0 +1,16 @@
+# Configuração do Ambiente de Desenvolvimento
+
+Para garantir a reprodutibilidade metodológica — requisito indispensável no escopo do TCC — detalha-se o processo de montagem do ambiente para compilação do código fonte do Argus Cyclist.
+
+## 1. Pré-requisitos de Sistema
+
+* **Compilador:** Go versão 1.21 ou superior (Necessário para suporte a concorrência avançada e generics).
+* **Node & Package Manager:** Node.js 18+ com NPM para compilação dos *assets* do Vite.
+* **Bibliotecas CGO (Linux/Ubuntu):** `sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev` (Essenciais para o motor de renderização da janela do sistema hospedeiro via Wails).
+* **CLI Engine:** Instalação global do Wails v2: `go install github.com/wailsapp/wails/v2/cmd/wails@latest`.
+
+## 2. Compilação e Execução
+
+1. Realize o clone do repositório: `git clone <repo-url> argus-cyclist`
+2. No diretório raiz, execute `wails dev`. O motor do Wails fará a ponte entre o servidor Go e ativará o modo *Hot-Reload* do Vite no navegador.
+3. Para compilar a *Release* final (binário executável sem dependências web visíveis), utilize: `wails build -clean`. O executável será gerado na pasta `build/bin`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Base de Conhecimento: Argus Cyclist
+
+Bem-vindo à documentação oficial do **Argus Cyclist**. Este espaço organiza o conhecimento técnico, as decisões arquiteturais e os artefatos acadêmicos necessários para o TCC (UERN) e o registro de software junto ao INPI.
+
+## Navegação Rápida
+
+1. **[01-Acadêmico](./01-academico/):** Fundamentação teórica, metodologia e problemáticas voltadas à disciplina de Pré-TCC.
+2. **[02-Projeto](./02-projeto/):** Definição do produto, visão de mercado e o que o sistema se propõe a resolver.
+3. **[03-Técnico](./03-tecnico/):** Detalhes de implementação, arquitetura Wails/Go e protocolos de comunicação (BLE/Strava).


### PR DESCRIPTION
### Summary
This PR introduces a comprehensive Markdown-based knowledge base under the `docs/` directory. It bridges the gap between our Go/Wails implementation and the academic requirements for the TCC, while also laying the groundwork for official software registration.

### Changes Included
* **`01-academico/`**: Added `problematica.md`, `justificativa.md`, and `metodologia.md` focusing on the socio-economic barriers of indoor cycling and our technical research approach.
* **`02-projeto/`**: Added product vision, user personas (elite vs. casual athletes), functional/non-functional requirements, and a technical glossary.
* **`03-tecnico/`**: Documented the Clean Architecture topology, BLE connection flows (FTMS/Power/Heart Rate), `.FIT` file persistence, the physics/metrics engine, and Strava API integration.

**Closes:** #202 