### PR TITLE
docs: update TCC documentation to reflect new architecture

### DIFF
--- a/docs/01-academico/metodologia.md
+++ b/docs/01-academico/metodologia.md
@@ -23,11 +23,12 @@ A arquitetura do Argus Cyclist foi projetada visando máxima modularidade e sepa
 
 ## 3. Implementação e Codificação
 
-O desenvolvimento foi segmentado em módulos autônomos:
+O desenvolvimento foi segmentado em módulos autônomos, passando por um recente processo de refatoração para escalabilidade e design *offline-first*:
 
-1. **Módulo de Hardware (`internal/service/ble`):** Implementação de clientes genéricos e *mocks* para varredura e conexão com sensores GATT.
-2. **Módulo de Simulação (`internal/service/sim`):** Desenvolvimento do motor físico que calcula velocidade e potência simulada com base na altimetria de arquivos GPX.
-3. **Módulo de Armazenamento e Exportação (`internal/service/fit` e `strava`):** Geração local e criptografada de tokens de sessão, e rotinas de upload *multipart* para a nuvem.
+1. **Módulo de Hardware (`internal/service/ble`):** Implementação de clientes genéricos e *mocks* para varredura e conexão com sensores GATT de forma concorrente.
+2. **Módulo de Simulação e Gamificação (`internal/service/sim`):** Desenvolvimento do motor físico para cálculo de velocidade/potência com suporte a interações em tempo real (Sprints, testes de FTP e desafios *King of the Mountain*).
+3. **Módulo de Persistência (*Repository Pattern*):** Implementação de acesso a banco de dados embutido (`internal/repository/sqlite`) e orquestração de transações via Padrão *Facade* (`internal/usecase/storage_facade`).
+4. **Módulo de Exportação (`internal/service/fit` e `strava`):** Geração estruturada de arquivos de sessão e rotinas de upload *multipart* seguras para APIs de terceiros.
 
 ## 4. Testes e Validação Experimental
 

--- a/docs/02-projeto/requisitos.md
+++ b/docs/02-projeto/requisitos.md
@@ -9,10 +9,12 @@ A especificação de requisitos do Argus Cyclist foi derivada da necessidade de 
 * **RF03 - Motor de Simulação GPX:** O sistema deve interpretar arquivos de rota (GPX) e calcular a velocidade virtual baseada no peso do atleta, potência gerada e inclinação do terreno.
 * **RF04 - Registro de Atividade (FIT SDK):** O sistema deve gerar arquivos binários no padrão `.fit` (Flexible and Interoperable Data Transfer), contendo todos os samples de telemetria da sessão.
 * **RF05 - Integração Strava API:** O sistema deve gerenciar a autenticação via OAuth 2.0 e realizar o upload automático de sessões finalizadas para o perfil do usuário.
+* **RF06 - Persistência de Dados Local:** O sistema deve armazenar os dados do usuário, configurações, histórico de atividades e recordes pessoais (PRs) localmente utilizando um banco de dados relacional embutido (SQLite).
+* **RF07 - Desafios e Gamificação:** O sistema deve apresentar desafios de segmentos (*Sprints* e *KOM - King of the Mountain*) e avaliações de capacidade (teste *FTP*) durante a simulação de rotas ou sessões livres.
 
 ## Requisitos Não Funcionais (RNF)
 
-* **RNF01 - Latência de Telemetria:** O tempo entre a recepção do pacote BLE e a atualização na interface visual não deve exceder 150ms.
+* **RNF01 - Latência de Telemetria:** O tempo entre a recepção do pacote BLE e a atualização na interface visual não deve exceder 150ms, utilizando um *Event Bus* no frontend para desacoplar a recepção de dados da renderização.
 * **RNF02 - Portabilidade Multiplataforma:** A base de código deve ser compilável para Windows (Wails), Linux e Android (Capacitor) sem perda de funcionalidades core.
 * **RNF03 - Estabilidade de Conexão:** O sistema deve implementar rotinas de auto-reconexão para sensores que percam sinal momentaneamente durante a sessão.
 * **RNF04 - Eficiência de Memória:** O backend em Go não deve exceder 200MB de footprint de memória durante a simulação ativa.

--- a/docs/02-projeto/visao-geral.md
+++ b/docs/02-projeto/visao-geral.md
@@ -10,5 +10,6 @@ O sistema atua como uma ponte inteligente entre o hardware esportivo (sensores d
 
 * **Interoperabilidade Total:** Suporte nativo aos protocolos padrão da indústria (BLE/FTMS/FE-C), garantindo que o atleta não fique preso a ecossistemas proprietários.
 * **Performance Computacional:** Utilização de processamento nativo em Go para manipulação de sinais de sensores, eliminando gargalos comuns em aplicações baseadas puramente em Electron ou Web.
-* **Sincronização Unificada:** Integração fluida com o Strava, permitindo que o ciclo de treino (da captura à análise social) ocorra em uma única interface.
-* **Simulação Física Realista:** Implementação de um motor de física que traduz gradientes de arquivos GPX em resistência real no equipamento, simulando a sensação de rodagem externa.
+* **Engajamento e Gamificação:** Inclusão de segmentos de desafio (Sprints e KOM - King of the Mountain) e testes de aptidão (FTP Assessment) para tornar a experiência imersiva e dinâmica.
+* **Sincronização Unificada e Persistência Local:** Armazenamento local robusto em SQLite garantindo funcionamento *offline* e modo *Dashboard* de estúdio, além da integração fluida com o Strava para o ciclo de treino completo.
+* **Simulação Física Realista:** Implementação de um motor de física que traduz gradientes de arquivos GPX em resistência real no equipamento, simulando a sensação de rodagem externa de maneira eficiente.

--- a/docs/03-tecnico/arquitetura.md
+++ b/docs/03-tecnico/arquitetura.md
@@ -9,11 +9,98 @@ O **Argus Cyclist** foi projetado sob os princípios da *Clean Architecture*, pr
 * **Frontend:** Implementado com Vite, Vue/Vanilla JS e CSS puro, focando em reatividade em tempo real (atualização de tela a 60fps) e suporte nativo a *Dark Mode*.
 * **Mobile (Cross-Platform):** Integração com **Capacitor** para encapsular a aplicação Web em binários para Android, reutilizando a interface e substituindo chamadas de hardware de desktop por APIs móveis.
 
-## 2. Topologia de Microsserviços Internos
+## 2. Topologia de Componentes Internos e Persistência
 
-A aplicação backend está subdividida em serviços de domínio estrito:
+A aplicação passou por uma refatoração arquitetural baseada no padrão *Repository* e *Facade* para maximizar a escalabilidade:
 
-* `ble`: Camada de abstração do hardware. Responsável pelo *scan* e *handshake* GATT.
-* `sim` (Engine de Simulação): Motor físico que processa vetores de inclinação (GPX) e potência do ciclista para calcular métricas derivadas (como velocidade virtual e arrasto).
-* `fit`: Serviço de processamento de matrizes de dados e serialização. Agrega as métricas de performance minuto a minuto e as converte no padrão binário `.fit`.
-* `strava`: Cliente REST para integração com a nuvem esportiva via OAuth 2.0.
+* **Módulos Core (`ble` e `sim`):** O módulo `ble` atua como camada de abstração do hardware (scan/handshake GATT). O motor de simulação `sim` processa fisicamente gradientes (GPX) e eventos de gamificação (KOM e Sprints).
+* **Persistência (`repository/sqlite`):** Implementação de repositórios granulares (`activity_repo`, `user_repo`, `power_repo`) conectados a um banco de dados SQLite local, substituindo serviços monolíticos de estado e garantindo disponibilidade *offline*.
+* **Casos de Uso (`usecase/storage_facade`):** Uma fachada que orquestra as interações entre os repositórios, simplificando a lógica de negócio do armazenamento e fornecendo uma interface limpa para os controladores Wails.
+* **Processamento FIT e Strava:** Serviços de serialização de métricas esportivas para o padrão binário `.fit` e integração em nuvem via OAuth 2.0.
+* **Frontend Desacoplado:** Adoção de um `TelemetryEventBus` no Vanilla JS, isolando o barramento de eventos de telemetria das rotinas de atualização do DOM (Canvas/UI), reduzindo *reflows* e garantindo 60fps na renderização de desafios virtuais.
+
+## 3. Diagrama de Arquitetura Geral
+
+O diagrama abaixo ilustra a interação entre as camadas do sistema, destacando a separação de responsabilidades e o fluxo de comunicação entre o Frontend (JS) e o Backend (Go).
+
+```mermaid
+graph TD
+    subgraph Frontend [Camada de Apresentação - Vanilla JS]
+        UI[Componentes UI / Canvas]
+        TEB[TelemetryEventBus]
+        UI <--> TEB
+    end
+
+    subgraph Bridge [Wails IPC Bridge]
+        Wails[Bindings Wails]
+    end
+
+    subgraph Backend [Camada de Aplicação - Go]
+        subgraph UseCases [Controladores e Casos de Uso]
+            WC[Workout Controller]
+            CC[Challenge Controller]
+            SF[Storage Facade]
+        end
+        
+        subgraph Core [Domínio e Serviços]
+            BLE[Serviço BLE / GATT]
+            SIM[Motor de Simulação Física]
+        end
+        
+        subgraph Repo [Camada de Persistência]
+            SQLite[(Banco SQLite Local)]
+            AR[Activity Repo]
+            UR[User Repo]
+            PR[Power Repo]
+            AR & UR & PR --> SQLite
+        end
+    end
+
+    subgraph Hardware [Equipamentos Físicos]
+        Sensors((Sensores BLE<br>HRM, Power, Trainer))
+    end
+    
+    subgraph Cloud [Nuvem]
+        Strava[Strava API]
+        FIT[.FIT Files]
+    end
+
+    TEB <--> Wails
+    Wails <--> WC
+    Wails <--> CC
+    Wails <--> SF
+    
+    WC --> SIM
+    WC --> BLE
+    CC --> SIM
+    
+    SF --> AR
+    SF --> UR
+    SF --> PR
+    
+    BLE <--> Sensors
+    
+    SF -.-> FIT
+    SF -.-> Strava
+```
+
+## 4. Fluxo de Comunicação de Telemetria (Tempo Real)
+
+A simulação de ciclismo virtual exige uma comunicação de baixíssima latência. O diagrama de sequência abaixo demonstra como os dados trafegam do sensor até a renderização gráfica no momento do pedal.
+
+```mermaid
+sequenceDiagram
+    participant S as Sensores BLE
+    participant B as Serviço BLE (Go)
+    participant E as Motor Simulação (Go)
+    participant W as Wails IPC
+    participant TB as TelemetryEventBus (JS)
+    participant C as Canvas / DOM (UI)
+
+    S->>B: Notificação GATT (Potência/Cadência)
+    B->>E: Envia Dados Brutos
+    E->>E: Calcula Velocidade (Física + GPX)
+    E->>W: Emite Evento Telemetria
+    W->>TB: Repassa Evento (JS)
+    TB->>C: Atualiza HUD (60fps) sem Reflow Global
+```

--- a/docs/03-tecnico/modelo-dados.md
+++ b/docs/03-tecnico/modelo-dados.md
@@ -17,6 +17,8 @@ Durante e após a sessão, o motor de métricas varre o array de `MetricSamples`
 * **Métricas de Agregação:** Potência Média (W), Frequência Cardíaca Média e Máxima, Cadência Média.
 * **Distribuição de Esforço:** Análise de picos de potência (ex: *Sprint* de 5, 10 e 30 segundos) com base no array consolidado.
 
-## 3. Persistência e Padrão `.FIT`
+## 3. Padrão `.FIT` e Persistência Relacional (SQLite)
 
 Para garantir que as métricas calculadas sejam aceitas universalmente, o Argus consolida os metadados e os *samples* 1Hz formatando-os rigorosamente no formato de arquivo **FIT (Flexible and Interoperable Data Transfer)**. Isso assegura interoperabilidade total com o Strava, TrainingPeaks e Garmin Connect.
+
+Além do arquivo físico gerado para exportação, o sistema implementa um **banco de dados relacional embarcado (SQLite)**. O modelo relacional (`internal/repository/sqlite/`) mapeia as estruturas para tabelas normalizadas (ex: `activities`, `power_records`, `users`), permitindo que o histórico e as métricas de evolução sejam consultadas diretamente no aplicativo através de um *Dashboard offline*, sem dependência de plataformas de terceiros.


### PR DESCRIPTION
Sync docs/tcc with main. Update markdown files to describe the new SQLite persistence layer, gamification features, and TelemetryEventBus optimization. Added Mermaid diagrams for system architecture and data flow.