### PR TITLE
fix: Scientific metrics tooltip and KB modal z-index overlap (#225)

### DIFF
--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -2692,7 +2692,7 @@ export class UIManager {
 
         // 3. Build the HTML template using Glassmorphism styling 
         const modalHtml = `
-            <div id="kb-modal" class="modal-overlay active" style="z-index: 9999; display: flex; align-items: center; justify-content: center; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.6); backdrop-filter: blur(5px);" onclick="if(event.target === this) this.remove()">
+            <div id="kb-modal" class="modal-overlay active" style="z-index: 120000; display: flex; align-items: center; justify-content: center; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.6); backdrop-filter: blur(5px);" onclick="if(event.target === this) this.remove()">
                 
                 <div class="glass-panel" style="background: rgba(21, 32, 54, 0.95); border: 1px solid rgba(255, 255, 255, 0.15); border-radius: 12px; padding: 30px; max-width: 550px; width: 90%; color: var(--text-main); position: relative; box-shadow: 0 10px 30px rgba(0,0,0,0.5); text-align: left; animation: fadeIn 0.3s ease;">
                     

--- a/frontend/src/styles/scientific-reference-tooltips.css
+++ b/frontend/src/styles/scientific-reference-tooltips.css
@@ -64,7 +64,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     box-shadow: 0 15px 35px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
     padding: 15px;
     width: 250px;
-    z-index: 9999;
+    z-index: 120000;
     transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     font-size: 0.8rem;
     text-align: left;


### PR DESCRIPTION
### **Description**
This PR fixes issue #225, where the scientific metrics tooltip and its detailed Knowledge Base modal were rendering behind other active modals, such as the Race History or Settings modal, making them unreadable.

### **Changes Made**
*   **`frontend/src/styles/scientific-reference-tooltips.css`**: Increased the `z-index` of `.tooltip-content` from `9999` to `120000`.
*   **`frontend/src/modules/UIManager.js`**: Increased the inline `z-index` of the `#kb-modal` (Knowledge Base modal) from `9999` to `120000`.

### **Why was this changed?**
The Race History modal (`#raceHistoryModal`) uses a `z-index` of `10005`, and the Activity Detail modal (`#activityDetailModal`) uses `110000`. The previous `z-index` of `9999` for the tooltips and the knowledge base modal was insufficient to bring them to the front. Updating them to `120000` guarantees they will correctly overlay any active modal or screen within the application.

### **How to Test**
1. Open the Race History modal (or Activity Detail modal).
2. Hover over or click on the `?` icon next to a scientific metric (e.g., TRIMP, Pw:HR Drift, IF, TSS).
3. Verify that the tooltip summary appears correctly **in front** of the active modal.
4. Click the `?` icon to open the deep-dive Knowledge Base modal.
5. Verify that the glassmorphism modal also renders correctly **in front** of the active modal.

Closes #225 
