### PR TITLE
fix(strava): handle 401 unauthorized errors and improve token refresh logic

### DIFF
--- a/app.go
+++ b/app.go
@@ -1648,6 +1648,7 @@ func (a *App) UploadLastWorkoutToStrava() (string, error) {
 
 		newTokens, err := strava.RefreshToken(profile.StravaRefreshToken)
 		if err != nil {
+			a.DisconnectStrava()
 			return "", fmt.Errorf("failed to auto-refresh token: %v", err)
 		}
 
@@ -1694,6 +1695,7 @@ func (a *App) UploadLastWorkoutToStrava() (string, error) {
 			fmt.Println("[STRAVA] Access Token invalid (401). Forcing refresh...")
 			newTokens, refreshErr := strava.RefreshToken(profile.StravaRefreshToken)
 			if refreshErr != nil {
+				a.DisconnectStrava()
 				return "", fmt.Errorf("failed to refresh token after 401: %v", refreshErr)
 			}
 			
@@ -1735,6 +1737,7 @@ func (a *App) UploadActivityToStrava(activityID uint) (string, error) {
 		fmt.Println("[STRAVA] Access Token Expired. Auto-refreshing...")
 		newTokens, err := strava.RefreshToken(profile.StravaRefreshToken)
 		if err != nil {
+			a.DisconnectStrava()
 			return "", fmt.Errorf("failed to auto-refresh token: %v", err)
 		}
 
@@ -1768,6 +1771,7 @@ func (a *App) UploadActivityToStrava(activityID uint) (string, error) {
 			fmt.Println("[STRAVA] Access Token invalid (401). Forcing refresh...")
 			newTokens, refreshErr := strava.RefreshToken(profile.StravaRefreshToken)
 			if refreshErr != nil {
+				a.DisconnectStrava()
 				return "", fmt.Errorf("failed to refresh token after 401: %v", refreshErr)
 			}
 			

--- a/app.go
+++ b/app.go
@@ -1690,7 +1690,28 @@ func (a *App) UploadLastWorkoutToStrava() (string, error) {
 
 	err = strava.UploadFitFile(profile.StravaAccessToken, latestFitFilePath)
 	if err != nil {
-		return "", err
+		if strings.Contains(err.Error(), "status 401") {
+			fmt.Println("[STRAVA] Access Token invalid (401). Forcing refresh...")
+			newTokens, refreshErr := strava.RefreshToken(profile.StravaRefreshToken)
+			if refreshErr != nil {
+				return "", fmt.Errorf("failed to refresh token after 401: %v", refreshErr)
+			}
+			
+			profile.StravaAccessToken = newTokens.AccessToken
+			profile.StravaRefreshToken = newTokens.RefreshToken
+			profile.StravaExpiresAt = newTokens.ExpiresAt
+			if dbErr := a.storageService.UpdateProfile(profile); dbErr != nil {
+				return "", fmt.Errorf("failed to save refreshed token: %v", dbErr)
+			}
+			
+			// Retry upload
+			err = strava.UploadFitFile(profile.StravaAccessToken, latestFitFilePath)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
 	}
 
 	// Mark the latest activity as uploaded in the database
@@ -1743,7 +1764,28 @@ func (a *App) UploadActivityToStrava(activityID uint) (string, error) {
 	// Upload to Strava API
 	err = strava.UploadFitFile(profile.StravaAccessToken, activity.Filename)
 	if err != nil {
-		return "", err
+		if strings.Contains(err.Error(), "status 401") {
+			fmt.Println("[STRAVA] Access Token invalid (401). Forcing refresh...")
+			newTokens, refreshErr := strava.RefreshToken(profile.StravaRefreshToken)
+			if refreshErr != nil {
+				return "", fmt.Errorf("failed to refresh token after 401: %v", refreshErr)
+			}
+			
+			profile.StravaAccessToken = newTokens.AccessToken
+			profile.StravaRefreshToken = newTokens.RefreshToken
+			profile.StravaExpiresAt = newTokens.ExpiresAt
+			if dbErr := a.storageService.UpdateProfile(profile); dbErr != nil {
+				return "", fmt.Errorf("failed to save refreshed token: %v", dbErr)
+			}
+			
+			// Retry upload
+			err = strava.UploadFitFile(profile.StravaAccessToken, activity.Filename)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
 	}
 
 	// Mark as uploaded in the local database

--- a/internal/service/strava/oauth.go
+++ b/internal/service/strava/oauth.go
@@ -80,6 +80,10 @@ func RefreshToken(refreshToken string) (*TokenResponse, error) {
 	clientID := os.Getenv("STRAVA_CLIENT_ID")
 	clientSecret := os.Getenv("STRAVA_CLIENT_SECRET")
 
+	if clientID == "" || clientSecret == "" {
+		return nil, fmt.Errorf("strava credentials not found in environment variables")
+	}
+
 	data := url.Values{}
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
@@ -97,9 +101,17 @@ func RefreshToken(refreshToken string) (*TokenResponse, error) {
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("strava refresh API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
 	var tokenResp TokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return nil, fmt.Errorf("failed to parse strava refresh response: %v", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("strava refresh succeeded but returned empty access token")
 	}
 
 	return &tokenResp, nil


### PR DESCRIPTION
## Description
This PR resolves an issue where users were experiencing an infinite loop of `401 Authorization Error` when attempting to upload activities to Strava with an expired, revoked, or missing token.

## Changes Made
- **Error interception on upload:** Added logic in `app.go` (`UploadActivityToStrava` and `UploadLastWorkoutToStrava`) to intercept `status 401` errors from Strava. If encountered, the app will now actively force a token refresh and retry the upload.
- **Robust `RefreshToken` validation:** Updated `internal/service/strava/oauth.go` to explicitly check for missing `.env` credentials and non-200 HTTP responses. It no longer silently parses Strava errors into empty structures.
- **Graceful disconnection:** If a token refresh completely fails (e.g., the user revoked app access or the `.env` file is missing), the application will now call `DisconnectStrava()`. This correctly clears the corrupted tokens from the database, preventing infinite retry loops and requiring the user to re-authenticate.

Closes #227 