### PR TITLE
fix: preserve gamification fields when updating user profile

### DIFF
--- a/internal/repository/sqlite/user_repo.go
+++ b/internal/repository/sqlite/user_repo.go
@@ -51,6 +51,21 @@ func (r *UserRepo) UpdateProfile(u domain.UserProfile) error {
 			u.StravaRefreshToken = existing.StravaRefreshToken
 			u.StravaExpiresAt = existing.StravaExpiresAt
 		}
+		if u.CurrentStreak == 0 {
+			u.CurrentStreak = existing.CurrentStreak
+		}
+		if u.LastWorkoutDate.IsZero() {
+			u.LastWorkoutDate = existing.LastWorkoutDate
+		}
+		if u.Theme == "" {
+			u.Theme = existing.Theme
+		}
+		if u.TotalCoins == 0 {
+			u.TotalCoins = existing.TotalCoins
+		}
+		if u.CreatedAt.IsZero() {
+			u.CreatedAt = existing.CreatedAt
+		}
 	}
 
 	// Always enforce ID 1 since it's an isolated DB per user


### PR DESCRIPTION
# Problem Description

Whenever the settings modal was closed or the user profile was updated from the frontend, the user's weekly streak (`CurrentStreak`) and the last workout date (`LastWorkoutDate`) were being reset to zero in the SQLite database (`argus_master.db` / user-specific database).

---

## Root Cause

Upon closing the settings modal or during level-up events, the frontend triggers `saveUserProfile()` to build and send a profile payload containing only user-configurable settings, such as:

- Rider weight
- Bike weight
- FTP
- Measurement units
- Other UI-configurable preferences

However, gamification-related fields such as:

- `current_streak`
- `last_workout_date`

are managed exclusively by the backend gamification system and therefore were **not included** in the frontend payload.

When the Go backend received this JSON and unmarshaled it into the `domain.UserProfile` struct, these omitted fields were automatically assigned Go's zero-values:

- `CurrentStreak` → `0`
- `LastWorkoutDate` → `time.Time{}` (zero time)

In `internal/repository/sqlite/user_repo.go`, the `UpdateProfile()` function used GORM's: