### PR TITLE
feat: implement recovery/consistency achievements & fix custom goal modal z-index

### DIFF
--- a/app.go
+++ b/app.go
@@ -533,12 +533,13 @@ func (a *App) SaveGeneratedGPX(name string, points []ExportPoint) string {
 		name = fmt.Sprintf("route_%s", time.Now().Format("20060102_1504"))
 	}
 
-	// 1. Create the XML content.
 	var sb strings.Builder
 	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.1" creator="Argus Cyclist">
   <trk>
-    <name>` + name + `</name>
+    <name>`)
+	sb.WriteString(name)
+	sb.WriteString(`</name>
     <trkseg>
 `)
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -655,7 +655,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </div>
     </div>
 
-    <div id="customGoalModal" class="modal-overlay">
+    <div id="customGoalModal" class="modal-overlay" style="z-index: 10020;">
         <div class="modal-content" style="max-width: 400px; width: 90%;">
             <div class="modal-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
                 <h3 style="margin: 0;">Set Custom Goal</h3>

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -1100,7 +1100,30 @@ export class UIManager {
                     // Heroic Deeds (Single Activity)
                     { id: 'century', name: 'Century Club', type: 'epic_ride', val: 100 },
                     { id: 'mtngoat', name: 'Mountain Goat', type: 'epic_climb', val: 1000 },
-                    { id: 'calories', name: 'Calories Burner', type: 'calories', val: 50000 }
+                    { id: 'calories', name: 'Calories Burner', type: 'calories', val: 50000 },
+
+                    // Daily Consistency (Streaks)
+                    { id: 'streak3d', name: 'Daily Habit (3 Days)', type: 'consistency', val: 3 },
+                    { id: 'streak5d', name: 'Consistency Champion (5 Days)', type: 'consistency', val: 5 },
+
+                    // Recovery & Rest
+                    { id: 'rest_is_training', name: 'Rest is Training', type: 'recovery', val: 1 },
+                    { id: 'active_recovery', name: 'Active Recovery', type: 'recovery', val: 2 },
+
+                    // Routines
+                    { id: 'early_bird', name: 'Early Bird', type: 'routine', val: 1 },
+                    { id: 'night_owl', name: 'Night Owl', type: 'routine', val: 2 },
+                    { id: 'quick_spin', name: 'Quick Spin', type: 'routine', val: 3 },
+
+                    // Explorer
+                    { id: 'explorer3', name: 'Explorer', type: 'explorer', val: 3 },
+                    { id: 'explorer6', name: 'Master Explorer', type: 'explorer', val: 6 },
+
+                    // Balance
+                    { id: 'perfect_harmony', name: 'Perfect Harmony', type: 'balance', val: 1 },
+
+                    // Cardio
+                    { id: 'cardio_recovery', name: 'Cardio Recovery Master', type: 'cardio', val: 30 }
                 ];
 
                 const getIcon = (type) => {
@@ -1113,6 +1136,12 @@ export class UIManager {
                         case 'calories': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2c1 2 2 3.5 4 5.5s2 4 2 6.5c0 4.5-2.5 7-6 7s-6-2.5-6-7c0-2.5 0.5-4.5 2.5-6.5S11 4 12 2z"></path></svg>`;
                         case 'epic_ride': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"></circle><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"></path></svg>`;
                         case 'epic_climb': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 20h5v-2a3 3 0 0 0-5.356-1.857C17.135 15.828 17 15.422 17 15s-.135-.828-.356-1.143A3 3 0 1 0 12 15c0 .422-.135.828-.356 1.143A3 3 0 1 0 7 15c0 .422-.135.828-.356 1.143A3 3 0 0 0 2 18v2h5m5 0h5"></path><path d="M12 10L12 2"></path><path d="M9 5l3-3 3 3"></path></svg>`;
+                        case 'consistency': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path></svg>`;
+                        case 'recovery': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path><path d="M12 8v8"></path><path d="M8 12h8"></path></svg>`;
+                        case 'routine': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="13" r="8"></circle><path d="M12 9v4l2 2"></path><path d="M5 3L2 6"></path><path d="M19 3l3 3"></path></svg>`;
+                        case 'explorer': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"></polygon></svg>`;
+                        case 'balance': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="2" x2="12" y2="22"></line><line x1="5" y1="7" x2="19" y2="7"></line><path d="M5 7L3 17h4L5 7zM19 7l-2 10h4l-2-10z"></path></svg>`;
+                        case 'cardio': return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"></path></svg>`;
                         default: return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="13" r="8"></circle><path d="M12 9v4l2 2"></path><path d="M10 2h4"></path></svg>`;
                     }
                 };
@@ -1123,7 +1152,16 @@ export class UIManager {
                     
                     if (achieved) {
                         bDiv.className = 'badge-item minimalist-badge';
-                        const tierColor = m.val >= 1000 || m.val >= 50 ? 'var(--argus-safe)' : (m.val >= 500 || m.val >= 25 ? '#3498db' : '#94a3b8');
+                        let tierColor = '#94a3b8';
+                        if (m.type === 'consistency') tierColor = '#e67e22';
+                        else if (m.type === 'recovery') tierColor = '#2ecc71';
+                        else if (m.type === 'routine') tierColor = '#f1c40f';
+                        else if (m.type === 'explorer') tierColor = '#9b59b6';
+                        else if (m.type === 'balance') tierColor = '#1abc9c';
+                        else if (m.type === 'cardio') tierColor = '#e74c3c';
+                        else if (m.val >= 1000 || m.val >= 50) tierColor = 'var(--argus-safe)';
+                        else if (m.val >= 500 || m.val >= 25) tierColor = '#3498db';
+
                         bDiv.innerHTML = `
                             <div class="badge-icon-wrap" style="color: ${tierColor};">${getIcon(m.type)}</div>
                             <strong style="font-size: 0.9rem; display: block; margin-top: 10px; color: #fff;">${m.name}</strong>
@@ -1670,9 +1708,9 @@ export class UIManager {
                         window.ui.showToast(`🎯 Goal Completed: ${summary.gamification.goals_completed[0].metric} target reached!`);
                     }, 1000);
                 }
-                if (summary.gamification.badges_earned && summary.gamification.badges_earned.length > 0) {
+                if (summary.gamification.badges_unlocked && summary.gamification.badges_unlocked.length > 0) {
                     setTimeout(() => {
-                        window.ui.showToast(`🏆 Badge Unlocked: ${summary.gamification.badges_earned[0].name}!`);
+                        window.ui.showToast(`🏆 Badge Unlocked: ${summary.gamification.badges_unlocked[0].name}!`);
                     }, 2500);
                 }
                 

--- a/gamification.go
+++ b/gamification.go
@@ -297,6 +297,208 @@ func (a *App) updateAndCheckBadges(totalXP *int64) []domain.UserBadge {
 		}
 	}
 	
+	// ====================================
+	// New Habit, Balance & Recovery Badges
+	// ====================================
+	profile, _ := a.storageService.GetProfile()
+
+	// 8. Daily Consistency Streaks
+	if len(allActivities) > 0 {
+		activityDays := make(map[string]bool)
+		var uniqueDays []time.Time
+		for _, act := range allActivities {
+			dateStr := act.CreatedAt.Format("2006-01-02")
+			if !activityDays[dateStr] {
+				activityDays[dateStr] = true
+				t, _ := time.Parse("2006-01-02", dateStr)
+				uniqueDays = append(uniqueDays, t)
+			}
+		}
+
+		maxConsecutive := 0
+		currentConsecutive := 0
+		var lastDay time.Time
+		for i, day := range uniqueDays {
+			if i == 0 {
+				currentConsecutive = 1
+			} else {
+				diffDays := day.Sub(lastDay).Hours() / 24.0
+				if diffDays >= 0.8 && diffDays <= 1.2 {
+					currentConsecutive++
+				} else if diffDays > 1.2 {
+					if currentConsecutive > maxConsecutive {
+						maxConsecutive = currentConsecutive
+					}
+					currentConsecutive = 1
+				}
+			}
+			lastDay = day
+		}
+		if currentConsecutive > maxConsecutive {
+			maxConsecutive = currentConsecutive
+		}
+
+		if !badgeMap["Daily Habit (3 Days)"] && maxConsecutive >= 3 {
+			b := domain.UserBadge{BadgeType: "consistency", Tier: 3, Name: "Daily Habit (3 Days)", AchievedAt: time.Now()}
+			a.storageService.SaveBadge(b)
+			unlocked = append(unlocked, b)
+			*totalXP += 800
+		}
+		if !badgeMap["Consistency Champion (5 Days)"] && maxConsecutive >= 5 {
+			b := domain.UserBadge{BadgeType: "consistency", Tier: 5, Name: "Consistency Champion (5 Days)", AchievedAt: time.Now()}
+			a.storageService.SaveBadge(b)
+			unlocked = append(unlocked, b)
+			*totalXP += 1500
+		}
+	}
+
+	// 9. Rest is Training & Overtraining Prevention
+	if !badgeMap["Rest is Training"] && len(allActivities) >= 2 {
+		for i := 0; i < len(allActivities)-1; i++ {
+			actA := allActivities[i]
+			actB := allActivities[i+1]
+			isHard := actA.TSS >= 100 || actA.TRIMP >= 120
+			if isHard {
+				hoursGap := actB.CreatedAt.Sub(actA.CreatedAt).Hours()
+				// 32 to 60 hours implies at least one full calendar day of rest between activities
+				if hoursGap >= 32.0 && hoursGap <= 60.0 {
+					b := domain.UserBadge{BadgeType: "recovery", Tier: 1, Name: "Rest is Training", AchievedAt: time.Now()}
+					a.storageService.SaveBadge(b)
+					unlocked = append(unlocked, b)
+					*totalXP += 1000
+					break
+				}
+			}
+		}
+	}
+
+	// 10. Active Recovery (Easy recovery spins)
+	if !badgeMap["Active Recovery"] {
+		for _, act := range allActivities {
+			if act.Duration >= 900 {
+				isLowHR := profile.MaxHR > 0 && act.AvgHR > 0 && act.AvgHR < int(0.60*float64(profile.MaxHR))
+				isLowPower := profile.FTP > 0 && act.AvgPower > 0 && act.AvgPower < int(0.55*float64(profile.FTP))
+				if isLowHR || isLowPower {
+					b := domain.UserBadge{BadgeType: "recovery", Tier: 2, Name: "Active Recovery", AchievedAt: time.Now()}
+					a.storageService.SaveBadge(b)
+					unlocked = append(unlocked, b)
+					*totalXP += 800
+					break
+				}
+			}
+		}
+	}
+
+	// 11. Time-of-day Routines (Early Bird / Night Owl) & Coffee Ride (Quick Spin)
+	hasEarlyBird := false
+	hasNightOwl := false
+	hasQuickSpin := false
+	for _, act := range allActivities {
+		hour := act.CreatedAt.Hour()
+		if hour >= 5 && hour < 8 {
+			hasEarlyBird = true
+		}
+		if hour >= 20 || hour < 4 {
+			hasNightOwl = true
+		}
+		if act.Duration >= 900 && act.Duration <= 1800 {
+			hasQuickSpin = true
+		}
+	}
+
+	if !badgeMap["Early Bird"] && hasEarlyBird {
+		b := domain.UserBadge{BadgeType: "routine", Tier: 1, Name: "Early Bird", AchievedAt: time.Now()}
+		a.storageService.SaveBadge(b)
+		unlocked = append(unlocked, b)
+		*totalXP += 500
+	}
+	if !badgeMap["Night Owl"] && hasNightOwl {
+		b := domain.UserBadge{BadgeType: "routine", Tier: 2, Name: "Night Owl", AchievedAt: time.Now()}
+		a.storageService.SaveBadge(b)
+		unlocked = append(unlocked, b)
+		*totalXP += 500
+	}
+	if !badgeMap["Quick Spin"] && hasQuickSpin {
+		b := domain.UserBadge{BadgeType: "routine", Tier: 3, Name: "Quick Spin", AchievedAt: time.Now()}
+		a.storageService.SaveBadge(b)
+		unlocked = append(unlocked, b)
+		*totalXP += 600
+	}
+
+	// 12. Route Explorer
+	if len(allActivities) > 0 {
+		uniqueRoutes := make(map[string]bool)
+		for _, act := range allActivities {
+			if act.RouteName != "" && act.RouteName != "Free Training" && act.RouteName != "KOM Event Segment" {
+				uniqueRoutes[act.RouteName] = true
+			}
+		}
+		numRoutes := len(uniqueRoutes)
+		if !badgeMap["Explorer"] && numRoutes >= 3 {
+			b := domain.UserBadge{BadgeType: "explorer", Tier: 3, Name: "Explorer", AchievedAt: time.Now()}
+			a.storageService.SaveBadge(b)
+			unlocked = append(unlocked, b)
+			*totalXP += 800
+		}
+		if !badgeMap["Master Explorer"] && numRoutes >= 6 {
+			b := domain.UserBadge{BadgeType: "explorer", Tier: 6, Name: "Master Explorer", AchievedAt: time.Now()}
+			a.storageService.SaveBadge(b)
+			unlocked = append(unlocked, b)
+			*totalXP += 1500
+		}
+	}
+
+	// 13. Perfect Harmony (Weekly balance)
+	if !badgeMap["Perfect Harmony"] && len(allActivities) >= 4 {
+		type weekKey struct {
+			year int
+			week int
+		}
+		weekActivityDays := make(map[weekKey]map[string]bool)
+		for _, act := range allActivities {
+			y, w := act.CreatedAt.ISOWeek()
+			key := weekKey{year: y, week: w}
+			if weekActivityDays[key] == nil {
+				weekActivityDays[key] = make(map[string]bool)
+			}
+			dateStr := act.CreatedAt.Format("2006-01-02")
+			weekActivityDays[key][dateStr] = true
+		}
+
+		hasPerfectHarmony := false
+		for _, daysMap := range weekActivityDays {
+			numActiveDays := len(daysMap)
+			if numActiveDays >= 4 && numActiveDays <= 5 {
+				hasPerfectHarmony = true
+				break
+			}
+		}
+
+		if hasPerfectHarmony {
+			b := domain.UserBadge{BadgeType: "balance", Tier: 1, Name: "Perfect Harmony", AchievedAt: time.Now()}
+			a.storageService.SaveBadge(b)
+			unlocked = append(unlocked, b)
+			*totalXP += 1200
+		}
+	}
+
+	// 14. Cardio Recovery Master
+	if !badgeMap["Cardio Recovery Master"] {
+		for _, act := range allActivities {
+			targetMaxHR := 150.0
+			if profile.MaxHR > 0 {
+				targetMaxHR = 0.80 * float64(profile.MaxHR)
+			}
+			if act.MaxHR >= int(targetMaxHR) && act.HRR1 >= 30 {
+				b := domain.UserBadge{BadgeType: "cardio", Tier: 30, Name: "Cardio Recovery Master", AchievedAt: time.Now()}
+				a.storageService.SaveBadge(b)
+				unlocked = append(unlocked, b)
+				*totalXP += 1000
+				break
+			}
+		}
+	}
+	
 	return unlocked
 }
 


### PR DESCRIPTION
## Overview
This PR introduces the new gamification system enhancements focused on daily habit consistency and balanced recovery, alongside a UI fix for overlapping modal overlays.

## Changes Included
### Gamification Backend & Frontend
* Added **11 new badges** calculated retroactively:
  * **Daily Habit & Consistency:** 3-day and 5-day streak badges.
  * **Rest is Training:** Encourages a rest day (32h to 60h gap) following a high-intensity ride.
  * **Active Recovery:** Encourages light sessions (≥ 15 min at low Power/Heart Rate).
  * **Early Bird / Night Owl:** Time-of-day habits.
  * **Quick Spin:** Encourages short daily habit-forming spins (15-30m).
  * **Explorer & Master Explorer:** Unique GPX route targets.
  * **Perfect Harmony:** Ensures a weekly training balance (4-5 days of training, 2-3 rest days).
  * **Cardio Recovery Master:** Tracks HRR1 ≥ 30 BPM after intense workouts.
* Integrated custom styled SVGs inside the Trophy Room page.
* Mapped `badges_unlocked` in the finish session modal toast notification helper to correctly pop up notifications when achievements are unlocked.

### UI & Layout Fix
* Added a specific inline style `z-index: 10020` on `#customGoalModal` in `index.html` to guarantee that the custom goal selector renders on top of the Trophy Room modal (`z-index: 10005`).

### Performance Cleanup
* Fixed strings concatenation memory allocations in `SaveGeneratedGPX` (`app.go`).

## How to Test
1. Checkout this branch: `git checkout feature/gamification-and-ui-fixes`.
2. Run `wails dev` or build the project.
3. Open the **Trophy Room** from the main controls and verify the new achievements load properly.
4. Click **New Goal** inside the Trophy Room and confirm the selector modal opens correctly on top of the Trophy Room overlay.
