### PR TITLE
fix(assessments): hide active goals widget during physiological tests

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -164,7 +164,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         </div>
                     </div>
                     
-                    <div class="dash-goals-widget" style="flex: 1; background: rgba(0,0,0,0.4); border-radius: 12px; padding: 15px; border: 1px solid rgba(255,255,255,0.05); display: flex; flex-direction: column;">
+                    <div id="dashGoalsWidget" class="dash-goals-widget" style="flex: 1; background: rgba(0,0,0,0.4); border-radius: 12px; padding: 15px; border: 1px solid rgba(255,255,255,0.05); display: flex; flex-direction: column;">
                         <h3 style="margin: 0 0 15px 0; color: var(--text-muted); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 1px;">Active Goals</h3>
                         <div id="dashboardGoalsList" style="overflow-y: auto; flex: 1; display: flex; flex-direction: column; gap: 10px;">
                             <div style="color: #888; font-size: 0.85rem; text-align: center; padding-top: 20px;">No active goals</div>

--- a/frontend/src/modules/WorkoutController.js
+++ b/frontend/src/modules/WorkoutController.js
@@ -117,6 +117,9 @@ export class WorkoutController {
 
             document.getElementById('dashboard-view').classList.remove('hidden');
 
+            const goalsWidget = document.getElementById('dashGoalsWidget');
+            if (goalsWidget) goalsWidget.style.display = 'none';
+
             if (window.ui) {
                 window.ui.isDashboardMode = true;
                 window.ui.initLiveChart();
@@ -165,6 +168,9 @@ export class WorkoutController {
 
         const leftSidebar = document.querySelector('.hud-sidebar:not(#workout-panel)');
         if (leftSidebar) leftSidebar.style.display = '';
+
+        const goalsWidget = document.getElementById('dashGoalsWidget');
+        if (goalsWidget) goalsWidget.style.display = '';
 
         if (window.ui) {
             window.ui.isDashboardMode = false;


### PR DESCRIPTION
## Description
When starting a physiological assessment (Ramp Test, 20-min FTP Test, or 5-min VO2Max Test), the "Active Goals" widget was still visible in the dashboard view, showing goal progress bars that would update during the test. This is misleading because assessment workouts are meant to measure baseline physiological metrics, not to progress custom goals.

This fix hides the goals widget container when a built-in assessment workout is loaded and restores it when the workout ends.

## Changes
- **frontend/index.html** — Added `id="dashGoalsWidget"` to the goals   widget wrapper for easy DOM access.
- **frontend/src/modules/WorkoutController.js** — In `loadWorkout()`,   hide the goals widget when `isTest` is true; in `hide()`, restore  its display so it reappears after the test.

## Testing
1. Create a custom goal
2. Click "Assessments" → select any test → "Proceed" → START
3. Toggle the dashboard view
4. Verify the "Active Goals" widget is not visible — only the live telemetry chart and metrics cards are shown
5. Stop or finish the test
6. Verify the goals widget reappears in the dashboard

Closes #240