### PR TITLE
fix: remove Active Goals widget from Dashboard view

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -178,12 +178,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         </div>
                     </div>
                     
-                    <div id="dashGoalsWidget" class="dash-goals-widget" style="flex: 1; background: rgba(0,0,0,0.4); border-radius: 12px; padding: 15px; border: 1px solid rgba(255,255,255,0.05); display: flex; flex-direction: column;">
-                        <h3 style="margin: 0 0 15px 0; color: var(--text-muted); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 1px;">Active Goals</h3>
-                        <div id="dashboardGoalsList" style="overflow-y: auto; flex: 1; display: flex; flex-direction: column; gap: 10px;">
-                            <div style="color: #888; font-size: 0.85rem; text-align: center; padding-top: 20px;">No active goals</div>
-                        </div>
-                    </div>
                 </div>
 
             </div>

--- a/frontend/src/modules/UIManager.js
+++ b/frontend/src/modules/UIManager.js
@@ -1229,7 +1229,6 @@ export class UIManager {
 
             const goals = await window.go.main.App.GetCustomGoals();
             const goalsList = document.getElementById('customGoalsList');
-            const dashGoalsList = document.getElementById('dashboardGoalsList');
             const completedGoalsList = document.getElementById('completedGoalsList');
             
             const activeGoals = goals ? goals.filter(g => g.status === 'active') : [];
@@ -1289,32 +1288,7 @@ export class UIManager {
                 }
             }
 
-            if (dashGoalsList) {
-                dashGoalsList.innerHTML = '';
-                if (!activeGoals || activeGoals.length === 0) {
-                    dashGoalsList.innerHTML = '<div style="color: #64748b; font-size: 0.8rem; text-align: center; padding: 20px;">No active goals</div>';
-                } else {
-                    activeGoals.forEach(g => {
-                        const progressPct = Math.min((g.current_progress / g.target_value) * 100, 100);
-                        const unit = g.metric === 'distance' ? 'km' : g.metric === 'elevation' ? 'm' : 'h';
-                        const gDiv = document.createElement('div');
-                        gDiv.style.cssText = 'background: rgba(255,255,255,0.02); padding: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,0.05); margin-bottom: 8px;';
-                        gDiv.innerHTML = `
-                            <div style="display: flex; justify-content: space-between; font-size: 0.75rem; margin-bottom: 6px;">
-                                <span style="color: #94a3b8; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;">${g.metric}</span>
-                                <span style="color: var(--argus-safe);">${Math.round(progressPct)}%</span>
-                            </div>
-                            <div class="xp-bar-bg" style="height: 3px; border-radius: 1.5px; background: rgba(0,0,0,0.2);">
-                                <div style="width: ${progressPct}%; height: 100%; background: var(--argus-safe); border-radius: 1.5px; box-shadow: 0 0 8px rgba(46, 204, 113, 0.3);"></div>
-                            </div>
-                            <div style="font-size: 0.65rem; color: #64748b; text-align: right; margin-top: 6px;">
-                                ${g.current_progress.toFixed(1)} / ${g.target_value}${unit}
-                            </div>
-                        `;
-                        dashGoalsList.appendChild(gDiv);
-                    });
-                }
-            }
+
         } catch (e) {
             console.error("Error loading trophy room:", e);
         }

--- a/frontend/src/modules/WorkoutController.js
+++ b/frontend/src/modules/WorkoutController.js
@@ -117,9 +117,6 @@ export class WorkoutController {
 
             document.getElementById('dashboard-view').classList.remove('hidden');
 
-            const goalsWidget = document.getElementById('dashGoalsWidget');
-            if (goalsWidget) goalsWidget.style.display = 'none';
-
             if (window.ui) {
                 window.ui.isDashboardMode = true;
                 window.ui.initLiveChart();
@@ -168,9 +165,6 @@ export class WorkoutController {
 
         const leftSidebar = document.querySelector('.hud-sidebar:not(#workout-panel)');
         if (leftSidebar) leftSidebar.style.display = '';
-
-        const goalsWidget = document.getElementById('dashGoalsWidget');
-        if (goalsWidget) goalsWidget.style.display = '';
 
         if (window.ui) {
             window.ui.isDashboardMode = false;


### PR DESCRIPTION
Closes #248 

Removes the "Active Goals" widget from the Toggle Dashboard view. The goals functionality remains fully available in the Trophy Room modal, eliminating the duplication.

### Changes:
- `frontend/index.html` — removed `#dashGoalsWidget` HTML block
- `frontend/src/modules/UIManager.js` — removed `dashboardGoalsList`
  rendering and DOM lookup
- `frontend/src/modules/WorkoutController.js` — removed
  `dashGoalsWidget` show/hide logic during fitness tests