### PR TITLE
fix: stop saving event mode rides as regular activities in user stats

### DIFF
--- a/app.go
+++ b/app.go
@@ -2046,49 +2046,9 @@ func (a *App) SaveEventResult(riderName string, mode string, score float64, stat
 		return err
 	}
 
-	// Also try to save as a regular activity in the rider's personal DB if they exist
-	localAccounts := a.storageService.GetLocalAccounts()
-	cleanName := riderName
-	if idx := strings.Index(riderName, " ["); idx != -1 {
-		cleanName = riderName[:idx]
-	}
-
-	var accountID string
-	for _, acc := range localAccounts {
-		if strings.EqualFold(acc.Name, cleanName) {
-			accountID = acc.ID
-			break
-		}
-	}
-
-	if accountID == "" && len(localAccounts) == 1 {
-		accountID = localAccounts[0].ID
-	}
-
-	if accountID != "" {
-		fmt.Printf("[EVENT] Saving activity for account: %s (%s)\n", cleanName, accountID)
-		// Switch to rider's DB
-		if err := a.storageService.LoadUserDatabase(accountID); err != nil {
-			fmt.Printf("[EVENT] Error loading user database: %v\n", err)
-		} else {
-			defer a.storageService.LoadUserDatabase("event-mode-shared")
-
-			activity := domain.Activity{
-				RouteName:      "Event: " + mode,
-				Filename:       filename,
-				TotalDistance:  0,
-				Duration:       int64(duration),
-				AvgPower:       int(score),
-				TotalElevation: 0,
-				CreatedAt:      time.Now(),
-			}
-			if err := a.storageService.SaveActivity(activity); err != nil {
-				fmt.Printf("[EVENT] Error saving activity: %v\n", err)
-			}
-		}
-	} else {
-		fmt.Printf("[EVENT] No local account found for rider: %s\n", cleanName)
-	}
+	// Note: We intentionally do NOT save an Activity to the user's personal DB here.
+	// Event results are stored exclusively in events_ranking.db via EventRecord
+	// to keep event mode completely separate from regular user statistics and history.
 
 	return nil
 }


### PR DESCRIPTION
## Description
Event mode rides (Sprint, KOM, Time Trial) were being saved as simplified `Activity` entries in the user's personal database, polluting total distance/time statistics, activity history, monthly calendar, and PMC calculations.

Event results were already correctly stored in `events_ranking.db` via `EventRecord`. The duplicated `Activity` save caused event mode data to leak into the regular user profile statistics.

## Changes
- **app.go**: Removed the code block in `SaveEventResult()` that saved a simplified `Activity` to the user's personal DB when the rider name matched a local account.

## What Remains Unaffected
- Event results continue to be saved to `events_ranking.db` via `EventRecord`
- FIT file generation for events (`workouts/events/`) is unchanged
- Leaderboard and Race History UI still work (they query `events_ranking.db`)
- All regular activity saving logic in `FinishSession()` is untouched

## Why This Is Safe
The event leaderboard, race history modal, and FIT export all read from `EventRecord` in `events_ranking.db`, not from the user's activities table. Removing this duplicate save has no impact on any event mode feature.

## Related Issue
Closes #253 