### PR TITLE
feat: enrich AI coach system prompt with detailed workout metrics

### DIFF
--- a/app.go
+++ b/app.go
@@ -2228,7 +2228,7 @@ func (a *App) AIChat(conversationID uint, message string) (AIChatResult, error) 
 		profile = domain.UserProfile{Name: "Ciclista", FTP: 200, Weight: 75, Level: 1}
 	}
 
-	recentActivities, _ := a.storageService.GetRecentActivities(3)
+	recentActivities, _ := a.storageService.GetRecentActivities(10)
 	totalActivities := a.storageService.GetActivityCount()
 	totalKm := a.storageService.GetTotalDistance() / 1000.0
 	totalHours := float64(a.storageService.GetTotalDuration()) / 3600.0

--- a/internal/service/ai/prompts.go
+++ b/internal/service/ai/prompts.go
@@ -23,20 +23,80 @@ import (
 
 func BuildSystemPrompt(profile domain.UserProfile, activities []domain.Activity, totalActivities int, totalKm float64, totalHours float64) string {
 	var recentActs string
-	limit := 2
+	limit := 10
 	if len(activities) < limit {
 		limit = len(activities)
 	}
 	for i := 0; i < limit; i++ {
 		a := activities[i]
-		recentActs += fmt.Sprintf("- %s: %.1f km, %d min\n",
+		hrStr := ""
+		if a.AvgHR > 0 {
+			hrStr = fmt.Sprintf(", FC %d bpm", a.AvgHR)
+			if a.MaxHR > 0 {
+				hrStr = fmt.Sprintf(", FC %d-%d bpm", a.AvgHR, a.MaxHR)
+			}
+		}
+		elevStr := ""
+		if a.ElevationGain > 0 {
+			elevStr = fmt.Sprintf(", elev %.0f m", a.ElevationGain)
+		}
+		powerStr := ""
+		if a.AvgPower > 0 {
+			powerStr = fmt.Sprintf(", %d W avg", a.AvgPower)
+		}
+		tssStr := ""
+		if a.TSS > 0 {
+			tssStr = fmt.Sprintf(", TSS %.0f", a.TSS)
+		}
+		npStr := ""
+		if a.NormalizedPower > 0 {
+			npStr = fmt.Sprintf(", NP %d", a.NormalizedPower)
+		}
+		ifStr := ""
+		if a.IntensityFactor > 0 {
+			ifStr = fmt.Sprintf(", IF %.2f", a.IntensityFactor)
+		}
+		recentActs += fmt.Sprintf("- %s: %.1f km, %d min%s%s%s%s%s%s\n",
 			a.CreatedAt.Format("2006-01-02"),
 			a.TotalDistance/1000.0,
 			a.Duration/60,
+			powerStr,
+			npStr,
+			tssStr,
+			ifStr,
+			hrStr,
+			elevStr,
 		)
 	}
 	if recentActs == "" {
 		recentActs = "- nenhuma\n"
+	}
+
+	avgTSS := 0.0
+	avgIF := 0.0
+	avgNP := 0.0
+	count := 0
+	for _, a := range activities {
+		if a.TSS > 0 {
+			avgTSS += a.TSS
+			count++
+		}
+		if a.IntensityFactor > 0 {
+			avgIF += a.IntensityFactor
+		}
+		if a.NormalizedPower > 0 {
+			avgNP += float64(a.NormalizedPower)
+		}
+	}
+	aggStr := ""
+	if count > 0 {
+		avgTSS /= float64(count)
+		avgIF /= float64(count)
+		avgNP /= float64(count)
+		aggStr = fmt.Sprintf(
+			"\nMÉDIAS DOS TREINOS:\n- TSS médio: %.0f\n- IF médio: %.2f\n- NP médio: %.0f W\n",
+			avgTSS, avgIF, avgNP,
+		)
 	}
 
 	return fmt.Sprintf(`Você é um treinador de ciclismo integrado ao Argus Cyclist. Responda no MESMO IDIOMA do usuário.
@@ -49,12 +109,11 @@ DADOS DO USUÁRIO:
 - Streak: %d dias
 - Total de atividades: %d
 - Total percorrido: %.1f km em %.1f horas
-
-Últimas atividades:
 %s
-
+Últimas atividades (mais recentes primeiro):
+%s
 REGRAS:
-1. Use os dados reais do usuário para responder
+1. Use os dados reais do usuário para responder, incluindo TSS, NP, IF, FC e elevação quando relevante
 2. Quando o usuário pedir um TREINO, responda com JSON. O campo "response" deve conter uma explicação curta. O campo "workout" deve conter o treino estruturado.
 3. Exemplo de resposta COM treino (soma total = 600+1200+1200+600 = 3600s = 60min):
 {"response":"Treino de 60min com aquecimento, intervalo e volta ao normal.","workout":{"name":"Treino Intervalado 60min","segments":[{"type":"Warmup","duration":600,"powerLow":0.5,"powerHigh":0.7},{"type":"SteadyState","duration":1200,"power":0.75},{"type":"IntervalsT","repeat":4,"onDuration":180,"onPower":1.1,"offDuration":120,"offPower":0.6},{"type":"Cooldown","duration":600,"powerLow":0.4,"powerHigh":0.6}]}}
@@ -74,6 +133,7 @@ IMPORTANTE:
 		totalActivities,
 		totalKm,
 		totalHours,
+		aggStr,
 		recentActs,
 	)
 }


### PR DESCRIPTION
### Description

**Problem**

The AI coach only sent the last 2 activities with minimal data (date, distance, duration) to the model. This prevented the AI from analyzing performance metrics like power, heart rate, TSS, or intensity — making it impossible to give context-aware training advice.

**Solution**

Send the last **10 activities** with full metrics to the model, plus computed aggregate averages across all workouts.

**Before** (per activity):
- 2026-05-30: 35.2 km, 60 min

**After** (per activity):
- 2026-05-30: 35.2 km, 60 min, 165 W avg, NP 172, TSS 92, IF 0.86, FC 148-172 bpm, elev 230 m

Plus aggregate stats:
MÉDIAS DOS TREINOS:
- TSS médio: 85
- IF médio: 0.72
- NP médio: 144 W

**What the AI can now do**

- Analyze TSS, NP, and IF progression over recent workouts
- Prescribe training respecting the athlete's real workload (avg TSS, IF)
- Cross-compare power vs heart rate, elevation vs performance
- Provide informed recovery or intensity recommendations

**Files changed**

| File | Change |
|------|--------|
| `app.go:2231` | `GetRecentActivities(3)` → `GetRecentActivities(10)` |
| `internal/service/ai/prompts.go` | Added TSS, NP, IF, HR, elevation per activity + aggregate averages |