### PR TITLE
fix: abort event challenges immediately and prevent state leaks

### DIFF
--- a/app.go
+++ b/app.go
@@ -953,7 +953,8 @@ func (a *App) FinishSession() (SessionSummary, error) {
 }
 
 // DiscardSession cancels the current session without saving any data.
-// Connected devices remain active.
+// Connected devices remain active. All session accumulators are reset
+// so that a new session starts from a clean state.
 func (a *App) DiscardSession() string {
 	if a.isRecording {
 		if a.cancelSim != nil {
@@ -962,8 +963,27 @@ func (a *App) DiscardSession() string {
 		a.isRecording = false
 		a.isPaused = false
 	}
+	a.cancelSim = nil
+
+	// Para o fluxo de telemetria (BLE mock) sem desconectar hardware
+	if a.trainerService != nil {
+		a.trainerService.UnsubscribeStats()
+	}
 
 	a.currentDist = 0
+	a.sessionPowerData = nil
+	a.sessionHRData = nil
+	a.sessionPowerSum = 0
+	a.sessionTicks = 0
+	a.sessionActiveTime = 0
+	a.sessionElevationGain = 0.0
+	a.lastAltitude = -9999.0
+	a.sessionStart = time.Time{}
+	a.workoutStartTimeOffset = 0
+	a.isCooldown = false
+	a.peakHR = 0
+	a.hrAt1Min = 0
+	a.hrAt2Min = 0
 
 	a.UnloadWorkout()
 

--- a/frontend/src/components/eventHubPage.html
+++ b/frontend/src/components/eventHubPage.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             <input type="text" id="eventRiderName" class="home-input" placeholder="Type your name"
                                 autocomplete="off"
                                 style="margin: 0; background: rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.1); font-size: 1rem; padding: 12px 10px; border-radius: 12px; font-weight: 500; flex: 1;">
-                            <select id="eventRiderGender" class="home-input"
-                                style="margin: 0; background: rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.1); font-size: 1rem; padding: 0 12px; border-radius: 12px; font-weight: 600; color: #fff; width: 85px; cursor: pointer;">
+                            <select id="eventRiderGender" class="home-input home-select"
+                                style="margin: 0; width: 110px; cursor: pointer;">
                                 <option value="G">All</option>
                                 <option value="M">Male</option>
                                 <option value="F">Female</option>
@@ -65,8 +65,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             Smart Equipment</div>
                         <div id="eventTrainerStatus" class="status-indicator"
                             style="font-weight: 800; font-size: 1.1rem; transition: color 0.3s;">Disconnected</div>
-                        <select id="eventTrainerList" class="hidden home-input"
-                            style="width: 100%; margin-top: 8px; padding: 8px; background: rgba(0,0,0,0.4); border: 1px solid rgba(255,255,255,0.1); color: #fff; border-radius: 8px;"></select>
+                        <select id="eventTrainerList" class="hidden home-input home-select"
+                            style="width: 100%; margin-top: 8px; margin-bottom: 0;"></select>
                     </div>
                     <div style="display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end;">
                         <button id="btnEventScanTrainer" class="btn-secondary" title="Scan Hardware"

--- a/frontend/src/modules/ChallengeController.js
+++ b/frontend/src/modules/ChallengeController.js
@@ -84,7 +84,8 @@ export class ChallengeController {
 
         window.challengeController = this;
 
-        telemetryBus.subscribe((data) => this.updateTelemetry(data));
+        this._telemetryCallback = (data) => this.updateTelemetry(data);
+        telemetryBus.subscribe(this._telemetryCallback);
 
         this.bindEvents();
         this.resizeCanvases();
@@ -618,15 +619,16 @@ export class ChallengeController {
     async stopBackendSession() {
         if (!window.isRecording) return;
 
+        window.isRecording = false;
+
         document.body.classList.add('suppress-map-modals');
+
+        if (this.ui && this.ui.setRecordingState) {
+            this.ui.setRecordingState('IDLE');
+        }
 
         if (window.go?.main?.App?.DiscardSession) {
             await window.go.main.App.DiscardSession();
-        }
-
-        window.isRecording = false;
-        if (this.ui && this.ui.setRecordingState) {
-            this.ui.setRecordingState('IDLE');
         }
 
         // Fully reset the main dashboard data so that when the Event Hub
@@ -1289,22 +1291,31 @@ export class ChallengeController {
     }
 
     async abortActiveChallenge({ reopenHub = true } = {}) {
-        if (!this.activeChallenge) return;
+        if (!this.activeChallenge || this.activeChallenge.finalized) return;
+        if (this._aborting) return;
+        this._aborting = true;
 
-        this.closeChallengeOverlay();
+        // Parar imediatamente — sem esperar backend
+        this.activeChallenge.finalized = true;
         this.stopAnimationLoop();
+        this.closeChallengeOverlay();
 
-        // Show the hub FIRST to cover the screen before backend cleanup
         if (reopenHub) {
             this.openEventHub();
         }
 
-        await this.stopBackendSession();
+        // UI já está limpa; backend pode terminar em background
+        try {
+            await this.stopBackendSession();
+        } catch (e) {
+            console.error('Error during backend session discard:', e);
+        }
         this.cleanupChallengeState();
     }
 
     cleanupChallengeState() {
         this.activeChallenge = null;
+        this._aborting = false;
         this.stopAnimationLoop();
         this.closeChallengeOverlay();
 

--- a/frontend/src/styles/home-screen-profile-selection.css
+++ b/frontend/src/styles/home-screen-profile-selection.css
@@ -421,6 +421,48 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
 }
 
+.home-input option {
+    background: #0a0a0c;
+    color: #fff;
+}
+
+select.home-select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: rgba(20, 24, 30, 0.8) !important;
+    border: 1px solid rgba(255, 255, 255, 0.15) !important;
+    color: #fff !important;
+    padding: 10px 36px 10px 16px !important;
+    border-radius: 12px !important;
+    font-weight: 600;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2338bdf8' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e") !important;
+    background-repeat: no-repeat !important;
+    background-position: right 14px center !important;
+    background-size: 15px !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
+}
+
+select.home-select:hover {
+    background-color: rgba(30, 35, 45, 0.9) !important;
+    border-color: rgba(56, 189, 248, 0.4) !important;
+}
+
+select.home-select:focus {
+    outline: none;
+    border-color: var(--power-color) !important;
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25) !important;
+}
+
+select.home-select option {
+    background-color: #0f1115 !important;
+    color: #e2e8f0 !important;
+    font-weight: 500;
+    padding: 10px;
+}
+
 .create-profile-form .btn-primary,
 .create-profile-form .btn-secondary {
     padding: 14px 20px;

--- a/frontend/src/styles/theme-2.css
+++ b/frontend/src/styles/theme-2.css
@@ -173,6 +173,11 @@ html[data-theme="day"] .history-item {
     padding: 10px;
 }
 
+#trainerList option {
+    background: #0a0a0c;
+    color: #fff;
+}
+
 .device-row.compact {
     padding: 5px 0;
     font-size: 0.85rem;

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -33,6 +33,9 @@ type TrainerService interface {
 	// SubscribeStats starts reading data from connected devices
 	SubscribeStats(dataChan chan Telemetry) error
 
+	// UnsubscribeStats stops the telemetry data flow without disconnecting hardware.
+	UnsubscribeStats()
+
 	// SetGrade sends the slope/grade to the trainer (if connected)
 	SetGrade(grade float64) error
 

--- a/internal/service/ble/mock.go
+++ b/internal/service/ble/mock.go
@@ -18,12 +18,15 @@ package ble
 
 import (
 	"argus-cyclist/internal/domain"
+	"sync"
 	"time"
 )
 
 // MockService simulates a trainer that responds to keyboard input
 type MockService struct {
+	mu           sync.Mutex
 	stopChan     chan struct{}
+	started      bool
 	currentPower int16
 	currentCad   uint8
 	currentHR    uint8
@@ -56,13 +59,16 @@ func (s *MockService) ConnectHR(macAddress string, onStatus func(string, string)
 }
 
 func (m *MockService) Disconnect() {
-	// Checks if the channel is already closed to avoid panic
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	select {
 	case <-m.stopChan:
 		return
 	default:
 		close(m.stopChan)
 	}
+	m.started = false
 }
 
 func (m *MockService) SetGrade(grade float64) error {
@@ -79,27 +85,58 @@ func (m *MockService) SetTrainerMode(mode string) {
 }
 
 func (m *MockService) SubscribeStats(ch chan domain.Telemetry) error {
-	m.stopChan = make(chan struct{})
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	go func() {
+	// Fecha canal anterior para parar goroutine velha antes de criar nova
+	if m.started {
+		select {
+		case <-m.stopChan:
+		default:
+			close(m.stopChan)
+		}
+	}
+
+	m.stopChan = make(chan struct{})
+	m.started = true
+
+	go func(stop chan struct{}) {
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 
 		for {
 			select {
-			case <-m.stopChan:
+			case <-stop:
 				return
 			case t := <-ticker.C:
-				ch <- domain.Telemetry{
+				select {
+				case ch <- domain.Telemetry{
 					Timestamp: t,
 					Power:     m.currentPower,
 					Cadence:   m.currentCad,
 					HeartRate: m.currentHR,
+				}:
+				case <-stop:
+					return
 				}
 			}
 		}
-	}()
+	}(m.stopChan)
 	return nil
+}
+
+func (m *MockService) UnsubscribeStats() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.started {
+		select {
+		case <-m.stopChan:
+		default:
+			close(m.stopChan)
+		}
+		m.started = false
+	}
 }
 
 func (m *MockService) DisconnectHR() {

--- a/internal/service/ble/real.go
+++ b/internal/service/ble/real.go
@@ -347,6 +347,15 @@ func (s *RealService) runControlLoop() {
 	}
 }
 
+func (s *RealService) UnsubscribeStats() {
+	// No-op for real BLE: notification callbacks are registered at the OS
+	// level via tinygo and persist across sessions. The same telemetry
+	// channel is reused, so data flow continues uninterrupted when a new
+	// game loop starts reading from it. Resetting the subscription flags
+	// would cause a second DiscoverServices + EnableNotifications on the
+	// next SubscribeStats, which breaks the BLE data flow on Linux/BlueZ.
+}
+
 func (s *RealService) SetGrade(grade float64) error {
 	s.controlMutex.Lock()
 	defer s.controlMutex.Unlock()


### PR DESCRIPTION
Frontend (ChallengeController.js):
- Stop telemetry subscription leak by storing callback reference
- Set challenge as finalized immediately on abort to prevent tick processing
- Add re-entrancy guard (_aborting flag) to prevent double-abort races
- Set window.isRecording before DiscardSession to avoid early return
- Keep telemetry subscription alive across challenges (required for _waitingForTelemetry and lastTelemetry updates)

Backend (TrainerService interface & implementations):
- Add UnsubscribeStats() to the TrainerService interface
- MockService: fix goroutine leak by closing old stopChan before creating new one; add mutex protection; make send non-blocking with select-default on stop
- RealService: UnsubscribeStats is a no-op — BLE notification callbacks persist at OS level (tinygo/BlueZ) and reuse the same telemetry channel

Backend (app.go):
- DiscardSession now resets all session accumulators (power/HR data, sums, ticks, elevation, cooldown state) for clean restart
- Call trainerService.UnsubscribeStats() to stop mock goroutine
- Set cancelSim = nil after use

UI (event hub & settings):
- Restyle native <select> dropdowns with dark background (home-select class) and custom chevron arrow
- Style <option> elements to use dark background instead of browser default white
- Remove redundant inline styles, rely on CSS classes