### PR TITLE
fix: prevent arrow key power adjustment from leaking to real trainer

### DIFF
--- a/app.go
+++ b/app.go
@@ -603,6 +603,7 @@ func (a *App) ConnectTrainer(macAddress string) (string, error) {
 
 	a.isTrainerConnected = true
 	a.isVirtualTrainer = false
+	a.simPower = 0
 	return "Trainer Connected", nil
 }
 
@@ -627,6 +628,7 @@ func (a *App) ConnectVirtualTrainer() (string, error) {
 
 	a.isTrainerConnected = true
 	a.isVirtualTrainer = true
+	a.simPower = 0
 	return "Simulator Active", nil
 }
 
@@ -638,6 +640,7 @@ func (a *App) DisconnectTrainer() string {
 		a.isTrainerConnected = false
 	}
 	a.isVirtualTrainer = false
+	a.simPower = 0
 	return "Disconnected"
 }
 
@@ -1007,6 +1010,8 @@ func (a *App) DisconnectDevice() string {
 	a.trainerService.Disconnect()
 	a.isTrainerConnected = false
 	a.isHRConnected = false
+	a.isVirtualTrainer = false
+	a.simPower = 0
 
 	runtime.EventsEmit(a.ctx, "status_change", "IDLE")
 	return "Disconnected"
@@ -1058,7 +1063,9 @@ func (a *App) gameLoop(ctx context.Context, input <-chan domain.Telemetry) {
 				lastHRTime = time.Now()
 			}
 
-			currentPower += a.simPower
+			if a.isVirtualTrainer {
+				currentPower += a.simPower
+			}
 
 			now := time.Now()
 
@@ -1312,6 +1319,10 @@ func (a *App) SetTrainerMode(mode string) {
 
 // ChangePowerSimulation is a placeholder for manual power simulation.
 func (a *App) ChangePowerSimulation(delta int) int {
+	if !a.isVirtualTrainer {
+		a.simPower = 0
+		return 0
+	}
 	a.simPower += int16(delta)
 
 	if a.simPower < -500 {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -531,13 +531,17 @@ function renderTrainerUIState(state) {
     });
 }
 
+let lastTrainerKind = 'real';
+
 async function refreshTrainerConnectionState() {
     if (window.go?.main?.App?.GetDeviceConnectionState) {
         const state = await window.go.main.App.GetDeviceConnectionState();
+        lastTrainerKind = state?.trainer_kind || 'real';
         renderTrainerUIState(state);
         return state;
     }
 
+    lastTrainerKind = 'real';
     return { trainer_connected: false, trainer_kind: 'real' };
 }
 window.refreshTrainerConnectionState = refreshTrainerConnectionState;
@@ -1236,6 +1240,13 @@ document.getElementById('btnFitnessTests').addEventListener('click', async () =>
 // =======================
 
 document.addEventListener('keydown', async (e) => {
+    // Ignorar quando o usuário estiver interagindo com input/select
+    const tag = e.target?.tagName?.toLowerCase();
+    if (tag === 'input' || tag === 'select' || tag === 'textarea') return;
+
+    // Só ajusta potência no simulador virtual
+    if (lastTrainerKind !== 'virtual') return;
+
     let delta = 0;
     if (e.key === "ArrowUp") delta = 10;
     if (e.key === "ArrowDown") delta = -10;


### PR DESCRIPTION
The global keyboard handler (ArrowUp/ArrowDown → ChangePowerSimulation) was firing for every key press regardless of the active trainer type. When the user switched from the virtual simulator to a real BLE trainer, arrow key presses could still reach the backend, which only guarded at the Go level (isVirtualTrainer check).

Changes:
- Track lastTrainerKind in the frontend via refreshTrainerConnectionState
- Guard the keydown handler with lastTrainerKind !== 'virtual' so that no RPC call is made when a real trainer is connected
- Skip the handler when the user is interacting with input/select/textarea elements, preventing arrow keys used for dropdown navigation from altering power