### PR TITLE
feat: decrease KOM mode max grade to 6%

### DIFF
--- a/app.go
+++ b/app.go
@@ -461,7 +461,7 @@ func (a *App) SetDirectGrade(grade float64) error {
 
 // SetKOMGradeSchedule creates a virtual KOM route with a custom grade schedule from frontend.
 func (a *App) SetKOMGradeSchedule(grades string) (string, error) {
-	gradeSchedule := []float64{0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8}
+	gradeSchedule := []float64{0, 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6}
 
 	if grades != "" {
 		var parsed []float64

--- a/frontend/src/modules/ChallengeController.js
+++ b/frontend/src/modules/ChallengeController.js
@@ -439,10 +439,10 @@ export class ChallengeController {
             { pct: 0.40, grade: 4 },
             { pct: 0.50, grade: 5 },
             { pct: 0.60, grade: 6 },
-            { pct: 0.70, grade: 7 },
-            { pct: 0.80, grade: 8 },
-            { pct: 0.90, grade: 8 },
-            { pct: 1.00, grade: 8 }
+            { pct: 0.70, grade: 6 },
+            { pct: 0.80, grade: 6 },
+            { pct: 0.90, grade: 6 },
+            { pct: 1.00, grade: 6 }
         ];
 
         const routeDistance = 3000;
@@ -463,7 +463,7 @@ export class ChallengeController {
         if (!window.go?.main?.App?.SetDirectGrade) return;
 
         const duration = 60;
-        const maxGrade = 7;
+        const maxGrade = 6;
         const pct = Math.min(1, elapsedSeconds / duration);
 
         let grade = 0;
@@ -540,10 +540,10 @@ export class ChallengeController {
             { pct: 0.40, grade: 4 },
             { pct: 0.50, grade: 5 },
             { pct: 0.60, grade: 6 },
-            { pct: 0.70, grade: 7 },
-            { pct: 0.80, grade: 8 },
-            { pct: 0.90, grade: 8 },
-            { pct: 1.00, grade: 8 }
+            { pct: 0.70, grade: 6 },
+            { pct: 0.80, grade: 6 },
+            { pct: 0.90, grade: 6 },
+            { pct: 1.00, grade: 6 }
         ];
 
         let currentEle = startEle;
@@ -1019,10 +1019,10 @@ export class ChallengeController {
             { pct: 0.40, grade: 4 },
             { pct: 0.50, grade: 5 },
             { pct: 0.60, grade: 6 },
-            { pct: 0.70, grade: 7 },
-            { pct: 0.80, grade: 8 },
-            { pct: 0.90, grade: 8 },
-            { pct: 1.00, grade: 8 }
+            { pct: 0.70, grade: 6 },
+            { pct: 0.80, grade: 6 },
+            { pct: 0.90, grade: 6 },
+            { pct: 1.00, grade: 6 }
         ];
 
         const routeDistance = 3000;


### PR DESCRIPTION
## Description

This Pull Request adjusts the maximum **KOM (King of the Mountain)** grade from **7% to 6%**, ensuring consistency between the backend simulation calculations and the frontend projections and visualizations.

## Changes Made

### 1. Backend (Go)

* **`app.go`**

  * Updated the default `gradeSchedule` in the `SetKOMGradeSchedule` method to cap the maximum grade at **6.0%** (previously it increased up to **8.0%**).
  * New default schedule:

    ```go
    []float64{0, 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6}
    ```

### 2. Frontend (JavaScript)

* **`ChallengeController.js`**

  * Updated the `maxGrade` constant from **7** to **6** inside the `updateKOMGradeByTime` function (time-based simulation).
  * Updated all `gradeSchedule` tables to cap the grade at **6%** (instead of increasing to **8%**) in the following methods:

    * `updateKOMGrade` (distance-based grade updates).
    * `createVirtualKOMRoute` (virtual route point generator).
    * `getGradeForDistance` (helper function for grade calculation).

---

## Verification and Testing

* **Frontend Build:** Successfully executed `npm run build` inside the `frontend/` directory.
* **Backend Compilation:** Successfully executed `go build` in the project root.
