### PR TITLE
fix: resolve race condition freezing interface on quick session switch

### DIFF
--- a/frontend/src/modules/ChallengeController.js
+++ b/frontend/src/modules/ChallengeController.js
@@ -401,6 +401,11 @@ export class ChallengeController {
     }
 
     async prepareChallengeEnvironment(mode) {
+        if (this._aborting) {
+            console.warn('Cannot start challenge: previous session is still cleaning up.');
+            return false;
+        }
+
         await this.refreshTrainerStatus();
 
         if (!await this.hasTrainerConnection()) {
@@ -1300,10 +1305,6 @@ export class ChallengeController {
         this.stopAnimationLoop();
         this.closeChallengeOverlay();
 
-        if (reopenHub) {
-            this.openEventHub();
-        }
-
         // UI já está limpa; backend pode terminar em background
         try {
             await this.stopBackendSession();
@@ -1311,6 +1312,10 @@ export class ChallengeController {
             console.error('Error during backend session discard:', e);
         }
         this.cleanupChallengeState();
+
+        if (reopenHub) {
+            this.openEventHub();
+        }
     }
 
     cleanupChallengeState() {


### PR DESCRIPTION
## Description

Fixes a race condition that could cause the Event Hub to freeze when switching rapidly between challenges.

## Root Cause

Previously, when closing or aborting a training mode, the frontend immediately reopened the main Event Hub (`this.openEventHub()`) while the backend was still asynchronously cleaning up the previous session (`DiscardSession()`). If the user quickly selected a new challenge, the new activation request could run in parallel with the cleanup process, causing the new session's telemetry channel to be unintentionally canceled and leaving the interface frozen.

## Changes Made

* **`ChallengeController.js`**

  * **Sequential reopening:** Moved the `this.openEventHub()` call in `abortActiveChallenge()` so it is executed **only after** the session shutdown (`await this.stopBackendSession()`) and application state cleanup (`this.cleanupChallengeState()`) have completed.
  * **Defensive guard:** Added a guard clause to `prepareChallengeEnvironment()` to abort initialization when `this._aborting` is already set, preventing concurrent keyboard events or session initialization from being triggered during the shutdown process.
