### PR TITLE
feat: scale up HUD components for presentation and fix css syntax warning

### DIFF
--- a/frontend/src/styles/home-screen-profile-selection.css
+++ b/frontend/src/styles/home-screen-profile-selection.css
@@ -711,15 +711,13 @@ select.home-select option {
     gap: 12px;
 }
 
-.challenge-card-grid {
-    @media (max-width: 900px) {
-        .settings-shell {
-            grid-template-columns: 1fr;
-        }
+@media (max-width: 900px) {
+    .settings-shell {
+        grid-template-columns: 1fr;
+    }
 
-        .settings-nav {
-            position: static;
-        }
+    .settings-nav {
+        position: static;
     }
 }
 

--- a/frontend/src/styles/studio-hud.css
+++ b/frontend/src/styles/studio-hud.css
@@ -29,7 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     z-index: 4000;
     display: flex;
     flex-direction: column;
-    padding: 2vh 3.5vw;
+    padding: 2.2vh 3.5vw;
     color: #f8fafc;
     overflow: hidden;
     font-family: 'Outfit', 'Inter', system-ui, -apple-system, sans-serif;
@@ -114,10 +114,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .hud-badge {
     font-weight: 900;
-    font-size: 0.95rem;
+    font-size: 1.15rem;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    padding: 8px 20px;
+    padding: 10px 24px;
     border-radius: 8px;
     background: rgba(15, 23, 42, 0.6);
     border: 1px solid rgba(255, 255, 255, 0.15);
@@ -152,15 +152,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .hud-rider {
     font-weight: 800;
-    font-size: 1rem;
+    font-size: 1.2rem;
     color: #e2e8f0;
-    max-width: 220px;
+    max-width: 250px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     background: rgba(15, 23, 42, 0.6);
     border: 1px solid rgba(255, 255, 255, 0.08);
-    padding: 8px 18px;
+    padding: 10px 22px;
     border-radius: 24px;
     display: inline-flex;
     align-items: center;
@@ -182,12 +182,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .hud-state {
     font-weight: 800;
-    font-size: 0.95rem;
+    font-size: 1.15rem;
     color: #94a3b8;
     white-space: nowrap;
     background: rgba(15, 23, 42, 0.65);
     border: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 8px 24px;
+    padding: 10px 28px;
     border-radius: 24px;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -243,10 +243,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-btn {
-    padding: 8px 18px;
+    padding: 10px 22px;
     border-radius: 10px;
     font-weight: 800;
-    font-size: 0.6rem;
+    font-size: 0.8rem;
     letter-spacing: 0.05em;
     text-transform: uppercase;
     cursor: pointer;
@@ -329,12 +329,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 32px;
-    padding: 3.5vh 5vw;
+    border-radius: 36px;
+    padding: 4vh 6vw;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2vh;
+    gap: 2.2vh;
     box-shadow:
         0 40px 100px -20px rgba(0, 0, 0, 0.8),
         inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -391,7 +391,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-hub-val {
-    font-size: clamp(5.5rem, 20vh, 14rem);
+    font-size: clamp(7rem, 25vh, 16.5rem);
     font-weight: 900;
     line-height: 0.75;
     font-variant-numeric: tabular-nums;
@@ -405,7 +405,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-hub-unit {
-    font-size: clamp(1.3rem, 3.5vh, 3rem);
+    font-size: clamp(1.6rem, 4vh, 3.5rem);
     font-weight: 900;
     color: #64748b;
     margin-top: -0.1em;
@@ -414,7 +414,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-hub-lbl {
-    font-size: 0.65rem;
+    font-size: 0.85rem;
     font-weight: 800;
     color: #94a3b8;
     letter-spacing: 0.4em;
@@ -426,23 +426,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 .hud-hub-target {
     display: flex;
     align-items: center;
-    gap: 8px;
-    margin-top: 8px;
+    gap: 10px;
+    margin-top: 10px;
     background: rgba(255, 255, 255, 0.05);
-    padding: 4px 16px;
+    padding: 6px 20px;
     border-radius: 100px;
     border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .hud-hub-target-lbl {
-    font-size: 0.55rem;
+    font-size: 0.7rem;
     font-weight: 800;
     color: #94a3b8;
     letter-spacing: 0.12em;
 }
 
 .hud-hub-target-val {
-    font-size: 0.85rem;
+    font-size: 1.05rem;
     font-weight: 800;
     color: #fbbf24;
 }
@@ -477,7 +477,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-hub-tic {
-    font-size: clamp(2.8rem, 10vh, 7rem);
+    font-size: clamp(3.8rem, 13vh, 9rem);
     font-weight: 900;
     line-height: 1;
     font-variant-numeric: tabular-nums;
@@ -488,7 +488,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-hub-tic-lbl {
-    font-size: 0.58rem;
+    font-size: 0.75rem;
     font-weight: 800;
     color: #475569;
     letter-spacing: 0.3em;
@@ -512,15 +512,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 20px;
-    padding: 16px 28px;
-    min-width: 160px;
+    border-radius: 24px;
+    padding: 20px 32px;
+    min-width: 180px;
     text-align: center;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 4px;
+    gap: 6px;
     box-shadow: 0 15px 45px -15px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.05);
     transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     position: relative;
@@ -565,7 +565,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 .mode-tt .hud-card:hover { border-color: rgba(168, 85, 247, 0.45); }
 
 .hud-card-lbl {
-    font-size: 0.6rem;
+    font-size: 0.8rem;
     font-weight: 800;
     color: #94a3b8;
     letter-spacing: 0.18em;
@@ -574,7 +574,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-card-val {
-    font-size: clamp(1.8rem, 4.5vh, 3.4rem);
+    font-size: clamp(2.4rem, 5.5vh, 4rem);
     font-weight: 900;
     color: #ffffff;
     line-height: 1;
@@ -584,7 +584,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-card-unit {
-    font-size: 0.75rem;
+    font-size: 0.95rem;
     font-weight: 800;
     color: #475569;
     text-transform: uppercase;
@@ -672,8 +672,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     display: flex;
     align-items: center;
     gap: 0;
-    padding: 12px 28px;
-    border-radius: 24px;
+    padding: 14px 32px;
+    border-radius: 28px;
     background: linear-gradient(180deg, rgba(15, 23, 42, 0.75) 0%, rgba(2, 6, 23, 0.9) 100%);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
@@ -685,12 +685,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 .hud-tray-cell {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 0 20px;
+    gap: 10px;
+    padding: 0 24px;
 }
 
 .hud-tray-key {
-    font-size: 0.7rem;
+    font-size: 0.85rem;
     font-weight: 800;
     color: #94a3b8;
     letter-spacing: 0.1em;
@@ -699,7 +699,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-tray-num {
-    font-size: clamp(1.2rem, 2.5vh, 1.8rem);
+    font-size: clamp(1.5rem, 3.2vh, 2.3rem);
     font-weight: 900;
     color: #ffffff;
     font-variant-numeric: tabular-nums;
@@ -707,7 +707,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .hud-tray-unit {
-    font-size: 0.75rem;
+    font-size: 0.9rem;
     font-weight: 800;
     color: #475569;
     text-transform: uppercase;
@@ -817,11 +817,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 24px;
-    padding: 24px 28px;
+    border-radius: 28px;
+    padding: 28px 32px;
     max-height: 65vh;
-    min-width: 400px;
-    width: 400px;
+    min-width: 440px;
+    width: 440px;
     overflow-y: auto;
     flex-shrink: 0;
     box-shadow: 0 25px 60px -15px rgba(0, 0, 0, 0.7), inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -835,7 +835,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .hud-lb .challenge-chip-label {
     display: block;
-    font-size: 0.8rem;
+    font-size: 0.95rem;
     font-weight: 900;
     color: #94a3b8;
     text-transform: uppercase;
@@ -848,14 +848,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .hud-lb .challenge-inline-entry {
     display: grid;
-    grid-template-columns: 28px 1fr auto;
-    gap: 12px;
+    grid-template-columns: 32px 1fr auto;
+    gap: 14px;
     align-items: center;
-    padding: 10px 16px;
-    border-radius: 10px;
+    padding: 12px 18px;
+    border-radius: 12px;
     background: rgba(255, 255, 255, 0.02);
     border-left: 2px solid rgba(255, 255, 255, 0.05);
-    font-size: 0.9rem;
+    font-size: 1.1rem;
     color: #94a3b8;
     margin-bottom: 8px;
     transition: all 0.2s ease-in-out;


### PR DESCRIPTION
## Description

This Pull Request improves the visibility of the **Sprint**, **KOM**, and **Time Trial** challenge interfaces by directly scaling the HUD for presentation purposes. It also fixes a CSS compilation warning.

## Changes Made

* **Direct HUD Scaling (~20%):** Increased the size of the challenge HUD by directly adjusting CSS typography (`font-size`, `clamp()`), spacing (`padding`, `gap`), component dimensions, and widths in `studio-hud.css`.
* **Viewport Bug Prevention:** Reverted the use of global `zoom` (which caused black borders and allowed home screen buttons to leak into the WebView), while keeping the HUD fixed with the native `inset: 0` layout to fully cover the viewport.
* **CSS Syntax Fix:** Corrected an improperly nested media query in `home-screen-profile-selection.css` that was generating a syntax warning during the Vite build.
* **Verification:** Successfully completed a production build (`npm run build`) with no warnings.
