### PR TITLE
feat: hide hud-tray-strip in sprint, kom, and timeTrial modes

### DIFF
--- a/frontend/src/styles/studio-hud.css
+++ b/frontend/src/styles/studio-hud.css
@@ -735,6 +735,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     display: none;
 }
 
+.mode-sprint .hud-tray-strip,
+.mode-kom .hud-tray-strip,
+.mode-tt .hud-tray-strip {
+    display: none !important;
+}
+
 /* Telemetry minimalist icons using SVG masks */
 .hud-tray-icon {
     width: 18px;


### PR DESCRIPTION
## Description

This Pull Request completely removes the bottom metrics bar (`hud-tray-strip`), which displays **heart rate**, **cadence**, and **W/kg**, from all three challenge modes: **Sprint**, **KOM**, and **Time Trial**.

## Changes Made

* **Metrics Bar Hidden:** Added a CSS rule to hide the `.hud-tray-strip` element (`display: none !important`) in `.mode-sprint`, `.mode-kom`, and `.mode-tt`.
* **Code Integrity Preserved:** The metrics bar is hidden via CSS rather than removed from the DOM, allowing the HUD controller scripts to continue updating the underlying elements without causing `null` reference errors.
* **Verification:** Successfully completed a production build using `npm run build`.
