### PR TITLE
fix: make real BLE notification writes non-blocking to prevent UI/BLE freeze

### DIFF
--- a/internal/service/ble/real.go
+++ b/internal/service/ble/real.go
@@ -239,8 +239,11 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 						char.EnableNotifications(func(buf []byte) {
 							p, c := fec.DecodeTrainerData(buf)
 							if p != -1 {
-								dataChan <- domain.Telemetry{
+								select {
+								case dataChan <- domain.Telemetry{
 									Power: p, Cadence: c, HeartRate: 0, Timestamp: time.Now(),
+								}:
+								default:
 								}
 							}
 						})
@@ -260,8 +263,11 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 					if uuid == CharCyclingPowerMeasure {
 						char.EnableNotifications(func(buf []byte) {
 							p, c := s.parseCyclingPower(buf)
-							dataChan <- domain.Telemetry{
+							select {
+							case dataChan <- domain.Telemetry{
 								Power: p, Cadence: c, HeartRate: 0, Timestamp: time.Now(),
+							}:
+							default:
 							}
 						})
 					}
@@ -286,8 +292,11 @@ func (s *RealService) SubscribeStats(dataChan chan domain.Telemetry) error {
 					if char.UUID() == CharHeartRateMeasure {
 						char.EnableNotifications(func(buf []byte) {
 							hr := parseHR(buf)
-							dataChan <- domain.Telemetry{
+							select {
+							case dataChan <- domain.Telemetry{
 								Power: -1, HeartRate: hr, Timestamp: time.Now(),
+							}:
+							default:
 							}
 						})
 					}


### PR DESCRIPTION
## Description

This Pull Request fixes a UI and Bluetooth adapter freezing issue that could occur when switching between or starting new challenge modes (for example, transitioning from **KOM** to **Time Trial** with a real smart trainer connected).

## Changes Made

* **Non-Blocking Telemetry Writes:** Updated all writes to `a.telemetryChan` within the Bluetooth notification handlers in `real.go` to use `select` statements with a `default` case, making telemetry writes non-blocking.
* **Bluetooth Deadlock Prevention:** When a challenge is completed or aborted and the simulation is no longer reading from the telemetry channel, pending Bluetooth packets are now dropped immediately instead of blocking the operating system's BLE adapter event thread indefinitely.
* **Verification:** Successfully compiled and tested locally.
