### PR TITLE
fix: prevent score accumulation and multiplier growth when stopped in time trial mode

### DIFF
--- a/frontend/src/modules/ChallengeController.js
+++ b/frontend/src/modules/ChallengeController.js
@@ -875,6 +875,16 @@ export class ChallengeController {
 
         if (!challenge.started) return;
 
+        if (power <= 0) {
+            challenge.consistencyHistory = [];
+            challenge.consistencyTimer = 0;
+            challenge.consistencyFactor = 1.0;
+            challenge.currentMultiplier = 1.0;
+            challenge.consecutiveTimeInZ5Plus = 0;
+            challenge.isZ5PlusActive = false;
+            return;
+        }
+
         const avgPower = challenge.powerHistory.reduce((a, b) => a + b, 0) / challenge.powerHistory.length;
         const pct = challenge.ftp > 0 ? (avgPower / challenge.ftp) * 100 : 0;
 
@@ -928,7 +938,7 @@ export class ChallengeController {
             const max = Math.max(...challenge.consistencyHistory);
             const min = Math.min(...challenge.consistencyHistory);
             const mean = challenge.consistencyHistory.reduce((a, b) => a + b, 0) / challenge.consistencyHistory.length;
-            const variation = mean > 0 ? ((max - min) / mean) * 100 : 0;
+            const variation = mean > 0 ? ((max - min) / mean) * 100 : 999;
 
             if (variation < 5) {
                 challenge.consistencyTimer += dt;


### PR DESCRIPTION
## Problem

In time trial mode, when the user stops pedaling (power drops to zero), two bugs occur:

1. **Score keeps accumulating**: There is no check for zero power, so points continue to accrue at the Z1 rate (1.0x multiplier) indefinitely while coasting.

2. **Multiplier grows exponentially**: The consistency logic samples the last 600 power readings (~10 min). After ~10 minutes of being stopped, the history fills with zeros — max=0, min=0, mean=0. The variation calculation (`mean > 0 ? ((max - min) / mean) * 100 : 0`) returns 0 because the ternary falls through to the `: 0` branch. Since `0 < 5` is true, the consistency timer keeps incrementing, and every 10 seconds the `consistencyFactor` grows by 20%. This causes the active multiplier to increase and score to accumulate at an accelerating rate while the user is completely stopped.

## Solution

Two changes in `frontend/src/modules/ChallengeController.js` -> `updateTimeTrial()`:

1. **Guard clause**: When `power <= 0`, all consistency state is reset (`consistencyHistory`, `consistencyTimer`, `consistencyFactor`, `consecutiveTimeInZ5Plus`, etc.) and the method returns early — no score is accumulated and the multiplier cannot grow.

2. **Defensive variation fallback**: Changed the ternary fallback from `0` to `999`, so that a zero-mean consistency history is treated as invalid data rather than "perfect consistency."